### PR TITLE
fixes portainer password issues in mailcow/mailcow-dockerized#228

### DIFF
--- a/docs/portainer.md
+++ b/docs/portainer.md
@@ -6,7 +6,7 @@ In order to enable Portainer, the docker-compose.yml and site.conf for nginx mus
       image: portainer/portainer
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
-        - /opt/portainer/data:/data
+        - ./data/conf/portainer:/data
       restart: always
       dns:
         - 172.22.1.254

--- a/docs/portainer.md
+++ b/docs/portainer.md
@@ -6,6 +6,7 @@ In order to enable Portainer, the docker-compose.yml and site.conf for nginx mus
       image: portainer/portainer
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
+        - /opt/portainer/data:/data
       restart: always
       dns:
         - 172.22.1.254


### PR DESCRIPTION
password setting had no persistent storage. added persistent storage per official compose docs: https://github.com/portainer/portainer-compose/blob/master/docker-compose.yml

I believe this issue lies from the fact that originally the dockerized version of portainer used http auth, but switched to app auth. Docs were never updated.