### PR TITLE
docker-compose down needed to enable IPv6

### DIFF
--- a/docs/install-update.md
+++ b/docs/install-update.md
@@ -55,6 +55,12 @@ docker rm $(docker ps -a -q)
 
 ### Step 2
 
+When upgrading from a version older than May 13th, 2017 to a version released after that date, you need to run the following command first as network settings have been changes:
+
+```
+docker-compose down
+```
+
 Pull new images (if any) and recreate changed containers:
 
 ```

--- a/docs/install-update.md
+++ b/docs/install-update.md
@@ -55,7 +55,7 @@ docker rm $(docker ps -a -q)
 
 ### Step 2
 
-When upgrading from a version older than May 13th, 2017 to a version released after that date, you need to run the following command first as network settings have been changes:
+When upgrading from a version older than May 13th, 2017 to a version released after that date, you need to run the following command first as network settings have been changed:
 
 ```
 docker-compose down


### PR DESCRIPTION
As requested in https://github.com/mailcow/mailcow-dockerized/pull/203, this PR documents that `docker-compose down` is needed after upgrading to the most recent version. If that isn't done, `docker-compose up -d presents the following error message:
```
ERROR: Network "mailcowdockerized_mailcow-network" needs to be recreated - enable_ipv6 has changed
```