### PR TITLE
Removed DKIM volume mentions, minor spelling + grammar

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,10 +56,9 @@ Each container represents a single application.
 - Rspamd
 - SOGo
 
-**7 volumes** to keep dynamic data - take care of them!
+**6 volumes** to keep dynamic data - take care of them!
 
 - vmail-vol-1
-- dkim-vol-1
 - redis-vol-1
 - mysql-vol-1
 - rspamd-vol-1

--- a/docs/prerequesite-system.md
+++ b/docs/prerequesite-system.md
@@ -16,12 +16,12 @@ Please make sure that your system has at least the following resources:
 | ----------------------- | --------------------- |
 | CPU                     | 1 GHz                 |
 | RAM                     | 1 GiB                 |
-| Disk                    | 5 GiB (without mails) |
+| Disk                    | 5 GiB (without emails)|
 | System Type             | x86_64                |
 
 ## Firewall & Ports
 
-Please check if any of mailcow's standard ports are open and not blocked by other applications:
+Please check if any of mailcow's standard ports are open and not in use by other applications:
 
 ```
 # netstat -tulpn | grep -E -w '25|80|110|143|443|465|587|993|995'


### PR DESCRIPTION
Seeing as DKIM volume is deprecated now, thought it may be worth removing from list of volumes to care about. 

Additionally, just some small readability changes in prerequisites page.