### PR TITLE
Added client_max_body_size option to nginx config

### DIFF
--- a/docs/firststeps-rp.md
+++ b/docs/firststeps-rp.md
@@ -61,6 +61,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 100m;
     }
     [...]
 }


### PR DESCRIPTION
I had a problem with my iPhone and SOGo (using EAS) when it was refusing to send a mail with a bigger attachment. The reason was that my reverse proxy was refusing files bigger than the default of 1 MB, that I had configured like given in the current documentation. So I just copied the same configuration line as already configured in the SOGo vhost ([link](https://github.com/mailcow/mailcow-dockerized/blob/master/data/conf/nginx/site.conf#L102))