### PR TITLE
Make backup scripts cron executable

### DIFF
--- a/docs/u_e-backup_restore-maildir.md
+++ b/docs/u_e-backup_restore-maildir.md
@@ -5,7 +5,7 @@ This line backups the vmail directory to a file backup_vmail.tar.gz in the mailc
 cd /path/to/mailcow-dockerized
 source mailcow.conf
 DATE=$(date +"%Y%m%d_%H%M%S")
-docker run --rm -it -v $(docker inspect --format '{{ range .Mounts }}{{ if eq .Destination "/var/vmail" }}{{ .Name }}{{ end }}{{ end }}' $(docker-compose ps -q dovecot-mailcow)):/vmail -v ${PWD}:/backup debian:jessie tar cvfz /backup/backup_vmail.tar.gz /vmail
+docker run --rm -i -v $(docker inspect --format '{{ range .Mounts }}{{ if eq .Destination "/var/vmail" }}{{ .Name }}{{ end }}{{ end }}' $(docker-compose ps -q dovecot-mailcow)):/vmail -v ${PWD}:/backup debian:jessie tar cvfz /backup/backup_vmail.tar.gz /vmail
 ```
 
 You can change the path by adjusting ${PWD} (which equals to the current directory) to any path you have write-access to.

--- a/docs/u_e-backup_restore-mysql.md
+++ b/docs/u_e-backup_restore-mysql.md
@@ -4,7 +4,7 @@
 cd /path/to/mailcow-dockerized
 source mailcow.conf
 DATE=$(date +"%Y%m%d_%H%M%S")
-docker-compose exec mysql-mailcow mysqldump --default-character-set=utf8mb4 -u${DBUSER} -p${DBPASS} ${DBNAME} > backup_${DBNAME}_${DATE}.sql
+docker-compose exec -T mysql-mailcow mysqldump --default-character-set=utf8mb4 -u${DBUSER} -p${DBPASS} ${DBNAME} > backup_${DBNAME}_${DATE}.sql
 ```
 
 ## Restore


### PR DESCRIPTION
The backup scripts of both mysql and maildir could not be executed by the cron daemon or similar services. I solved this by not allocating ttys when running `docker` / `docker-compose`.
