### PR TITLE
SOGo Integrator build instructions

### DIFF
--- a/docs/download/build-thunderbird-plugins.sh
+++ b/docs/download/build-thunderbird-plugins.sh
@@ -3,6 +3,10 @@
 set -e
 
 MAILHOST=$1
+if [ "$MAILHOST" = "" ]; then
+	echo "Usage: echo example.com example.org | $0 mailcow.example.com"
+	exit 1
+fi
 
 cd $(dirname $0)
 

--- a/docs/download/build-thunderbird-plugins.sh
+++ b/docs/download/build-thunderbird-plugins.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+MAILHOST=$1
+
+cd $(dirname $0)
+
+wget -O integrator.tar.gz https://github.com/inverse-inc/sogo-integrator.tb31/archive/master.tar.gz
+wget -O connector.tar.gz https://github.com/inverse-inc/sogo-connector.tb31/archive/master.tar.gz
+
+mkdir -p integrator connector
+tar --strip-components=1 -C integrator -xf integrator.tar.gz
+tar --strip-components=1 -C connector -xf connector.tar.gz
+
+# build custom integrator
+while read DOMAINS; do
+	for DOMAIN in $DOMAINS; do
+		echo "Building SOGo Integrator for $DOMAIN hosted on $MAILHOST"
+		cd integrator
+		echo > defaults/preferences/site.js
+		mkdir -p custom/${DOMAIN}
+		cp -r custom/sogo-demo/* custom/${DOMAIN}/
+		sed -i "s/http:\/\/sogo-demo\.inverse\.ca/https:\/\/${MAILHOST}/g" custom/${DOMAIN}/chrome/content/extensions.rdf
+		sed -i "s/plugins\/updates\.php[?]/thunderbird-plugins.php?domain=${DOMAIN}\&amp;/g" custom/${DOMAIN}/chrome/content/extensions.rdf
+		echo 'pref("sogo-integrator.autocomplete.server.urlid", "'${DOMAIN}'");' > custom/${DOMAIN}/defaults/preferences/site.js
+		echo 'pref("mail.collect_email_address_outgoing", false);' >> custom/${DOMAIN}/defaults/preferences/site.js
+		sed -i 's/<\/Seq>/<li><Description em:id="sieve@mozdev.org" em:name="Sieve"\/><\/li><li><Description em:id="imap-acl@sirphreak.com" em:name="Imap-ACL-Extension"\/><\/li><\/Seq>/g' custom/${DOMAIN}/chrome/content/extensions.rdf
+		make build=${DOMAIN}
+		INTEGRATOR_VER=$(grep em:version install.rdf | awk -F '"' '{print $2}')
+		cp sogo-integrator-*-${DOMAIN}.xpi ../sogo-integrator-${INTEGRATOR_VER}-${DOMAIN}.xpi
+		cd ..
+	done
+done
+
+# build connector
+cd connector
+make
+CONNECTOR_VER=$(grep em:version install.rdf | awk -F '"' '{print $2}')
+cp sogo-connector-*.xpi ../sogo-connector-${CONNECTOR_VER}.xpi
+cd ..
+
+# download Sieve plugin
+SIEVE_RELEASES=$(wget --header="Accept: application/vnd.github.v3+json" -qO - https://api.github.com/repos/thsmi/sieve/releases)
+SIEVE_VER=$(echo "$SIEVE_RELEASES" | grep -o '"tag_name": *"[^"]*"' | head -n 1 | awk -F '"' '{print $4}')
+SIEVE_URL=$(echo "$SIEVE_RELEASES" | grep -o '"browser_download_url": *"[^"]*"' | head -n 1 | awk -F '"' '{print $4}')
+wget -O sieve-${SIEVE_VER}.xpi ${SIEVE_URL}
+unset SIEVE_RELEASES
+
+# download ACL plugin
+IMAP_ACL_RELEASES=$(wget -qO - 'https://addons.mozilla.org/api/v3/addons/addon/176736')
+IMAP_ACL_VER=$(echo "$IMAP_ACL_RELEASES" | grep -o '"version": *"[^"]*"' | head -n 1 | awk -F '"' '{print $4}')
+IMAP_ACL_URL=$(echo "$IMAP_ACL_RELEASES" | grep -o '"url": *"[^"]*\.xpi' | head -n 1 | awk -F '"' '{print $4}')
+wget -O imap_acl_extension-${IMAP_ACL_VER}-tb.xpi ${IMAP_ACL_URL}
+unset IMAP_ACL_RELEASES
+
+# update version file
+echo "sogo-connector@inverse.ca;${CONNECTOR_VER};sogo-connector-${CONNECTOR_VER}.xpi" > version.csv
+echo "sogo-integrator@inverse.ca;${INTEGRATOR_VER};sogo-integrator-${INTEGRATOR_VER}-__DOMAIN__.xpi" >> version.csv
+echo "sieve@mozdev.org;${SIEVE_VER};sieve-${SIEVE_VER}.xpi" >> version.csv
+echo "imap-acl@sirphreak.com;${IMAP_ACL_VER};imap_acl_extension-${IMAP_ACL_VER}-tb.xpi" >> version.csv
+
+rm -rf connector integrator *.tar.gz

--- a/docs/download/thunderbird-plugins.php
+++ b/docs/download/thunderbird-plugins.php
@@ -1,0 +1,96 @@
+<?php
+/* updates.php - this file is part of SOGo
+ *
+ *  Copyright (C) 2006-2014 Inverse inc.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+/* This script handles the automatic propagation of extensions pertaining to a
+   SOGo site. It requires PHP 4.1.0 or later. */
+$plugin_dir = 'thunderbird-plugins';
+chdir($plugin_dir);
+$plugins = array();
+
+if (file_exists('version.csv'))
+{
+  $fh = fopen('version.csv', 'r');
+  if ($fh)
+  {
+    while (($row = fgetcsv($fh, 1000, ';')) !== FALSE)
+    {
+      $plugins[$row[0]] = array(
+        'application' => 'thunderbird',
+        'version' => $row[1],
+        'filename' => str_replace('__DOMAIN__', $_GET["domain"], $row[2]),
+      );
+    }
+    fclose($fh);
+  }
+}
+
+$applications
+= array( "thunderbird" => "<em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
+                <em:minVersion>31.0</em:minVersion>
+                <em:maxVersion>31.*</em:maxVersion>" );
+
+$pluginname = $_GET["plugin"];
+$plugin =& $plugins[$pluginname];
+$application =& $applications[$plugin["application"]];
+
+if ( $plugin ) {
+  $platform = $_GET["platform"];
+  if ( $platform
+       && file_exists( $platform . "/" . $plugin["filename"] ) ) {
+    $plugin["filename"] = $platform . "/" . $plugin["filename"];
+  }
+  elseif ( !file_exists( $plugin["filename"] ) ) {
+    $plugin = false;
+  }
+}
+
+if ( $plugin ) {
+  header("Content-type: text/xml; charset=utf-8");
+  echo ('<?xml version="1.0"?>' . "\n");
+?>
+<!DOCTYPE RDF>
+<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+  <Description about="urn:mozilla:extension:<?php echo $pluginname ?>">
+    <em:updates>
+      <Seq>
+        <li>
+          <Description>
+            <em:version><?php echo $plugin["version"] ?></em:version>
+            <em:targetApplication>
+              <Description>
+                <?php echo $applications[$plugin["application"]] ?>
+                
+                <em:updateLink><?php echo 'https://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['PHP_SELF']) . '/' .  $plugin_dir . '/' . $plugin["filename"] ?></em:updateLink>
+              </Description>
+            </em:targetApplication>
+          </Description>
+        </li>
+      </Seq>
+    </em:updates>
+  </Description>
+</RDF>
+<?php
+} else {
+  header("Content-type: text/plain; charset=utf-8", true, 404);
+  echo( 'Plugin not found' );
+}
+?>

--- a/docs/third_party-thunderbird.md
+++ b/docs/third_party-thunderbird.md
@@ -1,0 +1,27 @@
+# Build the SOGo Integrator plugin
+
+Install GNU Make, tar, and ZIP if you don't already have them installed. On Debian/Ubuntu, this can be done using
+
+```
+apt-get install make tar zip
+```
+
+Next, go to `data/web` inside mailcow-dockerized.
+Place the file [thunderbird-plugins.php](download/thunderbird-plugins.php) into that directory.
+Create a new directory `thunderbrid-plugins` and place the script [build-plugins.sh](download/build-thunderbird-plugins.sh) into it.
+Finally, execute the script with your hostname as an argument and piping it the names of all domains that Mailcow handles.
+All of this can be done using the following commands:
+
+```
+cd data/web
+curl -LO https://github.com/mailcow/mailcow-dockerized-docs/raw/master/docs/download/thunderbird-plugins.php
+mkdir thunderbird-plugins
+curl -Lo build-plugins.sh https://github.com/mailcow/mailcow-dockerized-docs/raw/master/docs/download/build-thunderbird-plugins.sh
+chmod +x build-plugins.sh
+echo example.com example.org | ./build-plugins.sh mailcow.example.com
+```
+
+# Install it in Thunderbird
+
+After you have set up your Mailcow IMAP account in Thunderbird, download the SOGo integrator plugin for your domain, e.g. https://mailcow.example.com/thunderbird-plugins/sogo-integrator-31.0.5-example.com.xpi, and install it into Thunderbird.
+All your address books and calendars will be configured automatically.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ pages:
   - 'Adjust Service Configurations': 'u_e-change_config.md'
   - 'Deinstall': 'u_e-deinstall.md'
 - 'Third party apps':
+  - 'Thunderbird': 'third_party-thunderbird.md'
   - 'Roundcube': 'third_party-roundcube.md'
   - 'Portainer': 'third_party-portainer.md'
   - 'Gogs': 'third_party-gogs.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,7 @@ pages:
   - 'Adjust Service Configurations': 'u_e-change_config.md'
   - 'Deinstall': 'u_e-deinstall.md'
 - 'Third party apps':
-  - 'Thunderbird': 'third_party-thunderbird.md'
+  - 'SOGo Integrator for Thunderbird': 'third_party-thunderbird.md'
   - 'Roundcube': 'third_party-roundcube.md'
   - 'Portainer': 'third_party-portainer.md'
   - 'Gogs': 'third_party-gogs.md'


### PR DESCRIPTION
https://github.com/mailcow/mailcow-dockerized/commit/2fadfee61a646d1b336b758657d756de7ab26272 removed the automatic build for the SOGo Integrator plugin. @andryyy suggested to move it to docs, so here it is.