### PR TITLE
_sieve._tcp SRV record

### DIFF
--- a/docs/prerequesite-dns.md
+++ b/docs/prerequesite-dns.md
@@ -51,13 +51,14 @@ _dmarc              IN TXT     "v=DMARC1; p=reject; rua=mailto:mailauth-reports@
 **SRV** records specify the server(s) for a specific protocol on your domain. If you want to explicitly announce a service as not provided, give "." as the target address (instead of "mail.example.tld."). Please refer to [RFC 2782](https://tools.ietf.org/html/rfc2782).
 
 ```
-_imap._tcp          IN SRV     0 1 143 mail.example.org.
-_imaps._tcp         IN SRV     0 1 993 mail.example.org.
-_pop3._tcp          IN SRV     0 1 110 mail.example.org.
-_pop3s._tcp         IN SRV     0 1 995 mail.example.org.
-_submission._tcp    IN SRV     0 1 587 mail.example.org.
-_smtps._tcp         IN SRV     0 1 465 mail.example.org.
-_autodiscover._tcp  IN SRV     0 1 443 autodiscover.example.org.
+_imap._tcp          IN SRV     0 1 143   mail.example.org.
+_imaps._tcp         IN SRV     0 1 993   mail.example.org.
+_pop3._tcp          IN SRV     0 1 110   mail.example.org.
+_pop3s._tcp         IN SRV     0 1 995   mail.example.org.
+_submission._tcp    IN SRV     0 1 587   mail.example.org.
+_smtps._tcp         IN SRV     0 1 465   mail.example.org.
+_sieve._tcp         IN SRV     0 1 4190  mail.example.org.
+_autodiscover._tcp  IN SRV     0 1 443   autodiscover.example.org.
 ```
 
 ## Testing


### PR DESCRIPTION
If Sieve is running on a port other than 4190, that can be announced using a _sieve._tcp SRV record, see RFC 5804, chapter 1.8.