### PR TITLE
Rspamd configuration moved to override.d

### DIFF
--- a/docs/firststeps-rspamd_ui.md
+++ b/docs/firststeps-rspamd_ui.md
@@ -5,7 +5,7 @@ At first you may want to setup Rspamds web interface which provides some useful 
 docker-compose exec rspamd-mailcow rspamadm pw
 ```
 
-2\. Replace the default hash in `data/conf/rspamd/override.d/worker-controller.inc` by your newly generated:
+2\. Add a line with your newly-generated hash to `data/conf/rspamd/override.d/worker-controller.inc`:
 ```
 enable_password = "myhash";
 ```

--- a/docs/u_e-change_config.md
+++ b/docs/u_e-change_config.md
@@ -51,13 +51,13 @@ data/conf
 │   │   ├── options.inc
 │   │   ├── redis.conf
 │   │   ├── rspamd.conf.local
-│   │   └── statistic.conf
+│   │   ├── statistic.conf
+│   │   ├── logging.inc
+│   │   ├── worker-controller.inc
+│   │   └── worker-normal.inc
 │   ├── lua
 │   │   └── rspamd.local.lua
-│   └── override.d
-│       ├── logging.inc
-│       ├── worker-controller.inc
-│       └── worker-normal.inc
+│   └── override.d (files in this directory can be created to override settings from files in local.d)
 └── sogo
     ├── sieve.creds
     └── sogo.conf


### PR DESCRIPTION
Documentation for https://github.com/mailcow/mailcow-dockerized/pull/627 . The rspamd password can now go into its own file and no longer needs to be inside a Git-managed file.