### PR TITLE
Rspamd configuration customization

### DIFF
--- a/docs/firststeps-rspamd_ui.md
+++ b/docs/firststeps-rspamd_ui.md
@@ -1,20 +1,3 @@
-At first you may want to setup Rspamds web interface which provides some useful features and information.
-
-1\. Generate a Rspamd controller password hash:
-```
-docker-compose exec rspamd-mailcow rspamadm pw
-```
-
-2\. Save your newly-generated hash by adding the following line to `data/conf/rspamd/override.d/worker-controller.custom.inc`:
-```
-enable_password = "myhash";
-```
-
-You can use `password = "myhash";` instead of `enable_password` to disable write-access in the web UI.
-
-3\. Restart rspamd:
-```
-docker-compose restart rspamd-mailcow
-```
-
-Open https://${MAILCOW_HOSTNAME}/rspamd in a browser and login!
+At first you may want to set up Rspamd's web interface, which provides some useful features and information.
+In the Mailcow web admin interface, go to the Debug page and set the Rspamd UI password.
+Then open https://${MAILCOW_HOSTNAME}/rspamd in a browser and log in!

--- a/docs/firststeps-rspamd_ui.md
+++ b/docs/firststeps-rspamd_ui.md
@@ -5,7 +5,7 @@ At first you may want to setup Rspamds web interface which provides some useful 
 docker-compose exec rspamd-mailcow rspamadm pw
 ```
 
-2\. Replace the default hash in `data/conf/rspamd/override.d/worker-controller.inc` by your newly generated:
+2\. Save your newly-generated hash by adding the following line to `data/conf/rspamd/override.d/worker-controller.custom.inc`:
 ```
 enable_password = "myhash";
 ```


### PR DESCRIPTION
Supersedes #46.

This is documentation for mailcow/mailcow-dockerized#629. The rspamd password can now go into its own file and no longer needs to be inside a Git-managed file.