### PR TITLE
Remove erroneous component of "cd" instruction

### DIFF
--- a/docs/third_party-roundcube.md
+++ b/docs/third_party-roundcube.md
@@ -1,6 +1,6 @@
 Download Roundcube 1.3.x to the web htdocs directory and extract it (here `rc/`):
 ```
-cd data/web/rc
+cd data/web
 wget -O - https://github.com/roundcube/roundcubemail/releases/download/1.3.x/roundcubemail-1.3.x-complete.tar.gz | tar xfvz -
 # Change folder name
 mv roundcubemail-1.3.x rc


### PR DESCRIPTION
Shouldn't be trying to cd into a directory that doesn't yet exist (this is created in the "mv" step just below)