### PR TITLE
Use stable channel for docker

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@ Quick installation for most operation systems:
 
 - Docker
 ```
-curl -sSL https://get.docker.com/ | sh
+curl -sSL https://get.docker.com/ | CHANNEL=stable sh
 ```
 
 - Docker-Compose


### PR DESCRIPTION
Since I ran into a docker issue (/run got filled with unneeded .pid files until the tempfs was full - see attached picture), which got fixed in https://github.com/moby/moby/pull/35484 and thus was present in a edge version of docker. My question is 'Hey why use a productive system with a non stable version of docker'

This PR will set the environment variable of `$CHANNEL` to `stable` so https://get.docker.com/ will install the stable version of docker.
I know that using the script isn't best practice, even a dev [said](https://github.com/docker/docker-install/issues/32) that the script isn't meant for production use, it's meant as a convenience to install the latest Docker CE version quickly, which includes edge versions and therefore in the [official docs](https://docs.docker.com/engine/installation/) there's nobody using this script.
I still suggest using this script, but please set the right environment variable

![chart2 php](https://user-images.githubusercontent.com/3279213/34456194-db28ec7a-ed90-11e7-82fa-d275d3335914.png)