### PR TITLE
add instruction for outlook 2016

### DIFF
--- a/docs/client-outlook.md
+++ b/docs/client-outlook.md
@@ -1,12 +1,12 @@
 <div class="client_outlookEAS_enabled" markdown="1">
 
-## Outlook 2016 on Windows
+## Outlook 2016 (from Office365) on Windows
 
 <div class="client_variables_unavailable" markdown="1">
   This is only applicable if your server administrator has not disabled EAS for Outlook. If it is disabled, please follow the guide for Outlook 2007 instead.
 </div>
 
-Outlook 2016 has an [issue with autodiscover](https://github.com/mailcow/mailcow-dockerized/issues/615). For EAS you must use the old Assistent:
+Outlook 2016 has an [issue with autodiscover](https://github.com/mailcow/mailcow-dockerized/issues/615). Only Outlook 2016 from Office365 is affected. If you installed Outlook 2016 from another source, please follow the guide for Outlook 2013 or higher. For EAS you must use the old Assistent:
 
 1. Launch `C:\Program Files (x86)\Microsoft Office\root\Office16\OLCFG.EXE`
 2. If this is the first time you launched Outlook, it asks you to add a new profile. After that the account setup can be started.
@@ -15,7 +15,7 @@ Outlook 2016 has an [issue with autodiscover](https://github.com/mailcow/mailcow
 6. Click the *Allow* button.
 7. Click *Finish*.
 
-## Outlook 2013 on Windows
+## Outlook 2013 or higher on Windows
 
 <div class="client_variables_unavailable" markdown="1">
   This is only applicable if your server administrator has not disabled EAS for Outlook. If it is disabled, please follow the guide for Outlook 2007 instead.

--- a/docs/client-outlook.md
+++ b/docs/client-outlook.md
@@ -1,6 +1,21 @@
 <div class="client_outlookEAS_enabled" markdown="1">
 
-## Outlook 2013 or higher on Windows
+## Outlook 2016 on Windows
+
+<div class="client_variables_unavailable" markdown="1">
+  This is only applicable if your server administrator has not disabled EAS for Outlook. If it is disabled, please follow the guide for Outlook 2007 instead.
+</div>
+
+Outlook 2016 has an [issue with autodiscover](https://github.com/mailcow/mailcow-dockerized/issues/615). For EAS you must use the old Assistent:
+
+1. Launch `C:\Program Files (x86)\Microsoft Office\root\Office16\OLCFG.EXE`
+2. If this is the first time you launched Outlook, it asks you to add a new profile. After that the account setup can be started.
+4. Enter your name<span class="client_variables_available"> (<code><span class="client_var_name"></span></code>)</span>, email address<span class="client_variables_available"> (<code><span class="client_var_email"></span></code>)</span> and your password. Click *Next*.
+5. When prompted, enter your password again, check *Remember my credentials* and click *OK*.
+6. Click the *Allow* button.
+7. Click *Finish*.
+
+## Outlook 2013 on Windows
 
 <div class="client_variables_unavailable" markdown="1">
   This is only applicable if your server administrator has not disabled EAS for Outlook. If it is disabled, please follow the guide for Outlook 2007 instead.


### PR DESCRIPTION
The new Outlook 2016 Setup Assistent for EAS didn't work with Mailcow. See this Issue with explanations from @mkuron: https://github.com/mailcow/mailcow-dockerized/issues/615#issuecomment-332317644

This PR add instruction for Outlook 2016 to the docs.