### PR TITLE
Remove everything containing rmilter because it is not used anymore

### DIFF
--- a/docs/debug-attach_service.md
+++ b/docs/debug-attach_service.md
@@ -27,15 +27,14 @@ docker-compose exec redis-mailcow redis-cli
 
 Here is a brief overview of what container / service does what:
 
-| Service Name  | Service Descriptions                                                      |
+| Service Name  | Service Descriptions                                                        |
 | --------------- | ------------------------------------------------------------------------- |
 | unbound-mailcow | Local (DNSSEC) DNS Resolver                                               |
-| mysql-mailcow   | Stores SOGo's and most of mailcow's settings                                         |
+| mysql-mailcow   | Stores SOGo's and most of mailcow's settings                              |
 | postfix-mailcow | Receives and sends mails                                                  |
 | dovecot-mailcow | User logins and sieve filter                                              |
-| redis-mailcow   | Storage back-end for DKIM keys, Rmilter and Rspamd                         |
+| redis-mailcow   | Storage back-end for DKIM keys and Rspamd                                 |
 | rspamd-mailcow  | Mail filtering system. Used for av handling, dkim signing, spam handling  |
-| rmilter-mailcow | Integrates Rspamd into postfix                                            |
 | clamd-mailcow   | Scans attachments for viruses                                             |
 | sogo-mailcow    | Webmail client that handles Microsoft ActiveSync and Cal- / CardDav       |
 | nginx-mailcow   | Nginx remote proxy that handles all mailcow related HTTP / HTTPS requests |

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,6 @@ Each container represents a single application.
 - Postfix
 - ACME-Client (thanks to @bebehei)
 - Nginx
-- Rmilter
 - Rspamd
 - SOGo
 - Fail2ban-like integration by @mkuron

--- a/docs/u_e-change_config.md
+++ b/docs/u_e-change_config.md
@@ -37,8 +37,6 @@ data/conf
 │       ├── mysql_virtual_relay_domain_maps.cf
 │       ├── mysql_virtual_sender_acl.cf
 │       └── mysql_virtual_spamalias_maps.cf
-├── rmilter
-│   └── rmilter.conf
 ├── rspamd
 │   ├── dynmaps
 │   │   ├── authoritative.php


### PR DESCRIPTION
As seen in https://github.com/mailcow/mailcow-dockerized/issues/945