### PR TITLE
Fix markdown error in update guide

### DIFF
--- a/docs/install-update.md
+++ b/docs/install-update.md
@@ -22,7 +22,7 @@ Some minor conflicts will be auto-corrected (in favour for the mailcow: dockeriz
 # Update with merge strategy "ours" instead of "theirs" 
 # This will merge in favor for your local changes.
 ./update.sh --ours
-# 
+```
 
 ## Manual update
 


### PR DESCRIPTION
The markdown rendering is currently messed up because the end of a code block was missing.