### PR TITLE
Fix cronjob errors of Dovecot expunge

### DIFF
--- a/docs/u_e-dovecot-expunge.md
+++ b/docs/u_e-dovecot-expunge.md
@@ -31,8 +31,9 @@ If you want to automate such a task you can create a cron job on your host that 
 
 ```
 #!/bin/bash
-/usr/local/bin/docker-compose exec dovecot-mailcow doveadm expunge -A mailbox 'Junk' savedbefore 2w
-/usr/local/bin/docker-compose exec dovecot-mailcow doveadm expunge -A mailbox 'Junk' SEEN not SINCE 12h
+cd /opt/mailcow-dockerized
+/usr/local/bin/docker-compose exec -T dovecot-mailcow doveadm expunge -A mailbox 'Junk' savedbefore 2w
+/usr/local/bin/docker-compose exec -T dovecot-mailcow doveadm expunge -A mailbox 'Junk' SEEN not SINCE 12h
 [...]
 ```
 

--- a/docs/u_e-dovecot-expunge.md
+++ b/docs/u_e-dovecot-expunge.md
@@ -31,7 +31,9 @@ If you want to automate such a task you can create a cron job on your host that 
 
 ```
 #!/bin/bash
-cd /opt/mailcow-dockerized
+# Path to mailcow-dockerized, e.g. /opt/mailcow-dockerized
+cd /path/to/your/mailcow-dockerized
+
 /usr/local/bin/docker-compose exec -T dovecot-mailcow doveadm expunge -A mailbox 'Junk' savedbefore 2w
 /usr/local/bin/docker-compose exec -T dovecot-mailcow doveadm expunge -A mailbox 'Junk' SEEN not SINCE 12h
 [...]


### PR DESCRIPTION
Recently, I discovered that the cronjob on my mailcow-dockerized host isn't working.
If the script is called via crontab, the docker-compose command doesn't know where the config file is located. So I added the "cd" to change the directory to the working directory of the mailcow-dockerized instance.
When executing the docker-compose exec command via cronjob, it fails with error message "the input device is not a TTY". By adding the parameter "-T" it works.