### PR TITLE
Update Received header

### DIFF
--- a/docs/u_e-postfix-anonym_headers.md
+++ b/docs/u_e-postfix-anonym_headers.md
@@ -1,8 +1,7 @@
 To disguise your users details like IP, email client, etc. we have to create a new file in `data/conf/postfix/mailcow_anonymize_headers.pcre` and insert the following:
 
 ```
-/^\s*Received:[^\)]+\)\s+\(Authenticated sender:(.+)/
-	REPLACE Received: from localhost (localhost [127.0.0.1]) (Authenticated sender:$1
+/^\s*Received:[^\n]*(.*)/         REPLACE Received: from localhost (localhost [127.0.0.1]) $1
 /^\s*User-Agent/        IGNORE
 /^\s*X-Enigmail/        IGNORE
 /^\s*X-Mailer/          IGNORE


### PR DESCRIPTION
/^\s*Received:[^\)]+\)\s+\(Authenticated sender:(.+)/ won't work as it does show the client's hostname + ip address with some mail clients.
For example Outlook 2016: "Received: from DESKTOPFREGERG5656 (hostname.provider.be [84.84.84.84]"
This is obviously not the intention.

Secondly, the replacement should be on 1 single line. 
The original header replacement parameter is on two lines and does not always work (tested).

This commit addresses the above problems.