### PR TITLE
Fix broken URL

### DIFF
--- a/docs/prerequisite-system.md
+++ b/docs/prerequisite-system.md
@@ -6,7 +6,7 @@ Before you run **mailcow: dockerized**, there are a few requirements that you sh
 !!! info
     - mailcow: dockerized requires [some ports](#default-ports) to be open for incoming connections, so make sure that your firewall is not blocking these.
     - Make sure that no other application is interfering with mailcow's configuration, such as another mail service
-    - A correct DNS setup is crucial to every good mailserver setup, so please make sure you got at least the [basics](prerequisite-dns/#the-minimal-dns-configuration) covered before you begin!
+    - A correct DNS setup is crucial to every good mailserver setup, so please make sure you got at least the [basics](https://mailcow.github.io/mailcow-dockerized-docs/prerequisite-dns/) covered before you begin!
     - Make sure that your system has a correct date and [time setup](#date-and-time). This is crucial for stuff like two factor TOTP authentication.
 
 ## Minimum System Resources


### PR DESCRIPTION
DNS configuration docs got moved to: https://mailcow.github.io/mailcow-dockerized-docs/prerequisite-dns/