### PR TITLE
Update Gitea version to use latest stable version

### DIFF
--- a/docs/third_party-gitea.md
+++ b/docs/third_party-gitea.md
@@ -7,7 +7,7 @@ version: '2.1'
 services:
 
 		gitea-mailcow:
-			image: gitea/gitea:latest
+			image: gitea/gitea:1
 			volumes:
 				- ./data/gitea:/data
 			networks:


### PR DESCRIPTION
The tag latest is used to build the :latest version from master which does not have to be stable the tag :1 is used for all releases with version 1.x.x .