### PR TITLE
Remove port from hostname specifications

### DIFF
--- a/docs/client/client-kontact.md
+++ b/docs/client/client-kontact.md
@@ -10,7 +10,7 @@
 10. Choose *DAV groupware resource* and click *OK*.
 11. Enter your email address<span class="client_variables_available"> (<code><span class="client_var_email"></span></code>)</span> and your password. Click *Next*.
 12. Select *ScalableOGo* from the dropdown menu and click *Next*.
-13. Enter<span class="client_variables_available"> <code><span class="client_var_host"></span><span class="client_var_port"></span></code></span><span class="client_variables_unavailable"> your mailcow hostname</span> into the *Host* field and click *Next*.
+13. Enter<span class="client_variables_available"> <code><span class="client_var_host"></span></code></span><span class="client_variables_unavailable"> your mailcow hostname</span> into the *Host* field and click *Next*.
 14. Click *Test Connection* and then *Finish*. Finally, click *OK* twice.
 
 Once you have set up Kontact, you can also use KMail, KOrganizer and KAddressBook individually.

--- a/docs/client/client-manual.md
+++ b/docs/client/client-manual.md
@@ -4,12 +4,12 @@ These instructions are valid for unchanged port bindings only!
 
 |Service|Encryption|Host|Port|
 |--- |--- |--- |--- |
-|IMAP|STARTTLS|<span class="client_variables_available"> <code><span class="client_var_host"></span><span class="client_var_port"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|143|
-|IMAPS|SSL|<span class="client_variables_available"> <code><span class="client_var_host"></span><span class="client_var_port"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|993|
-|POP3|STARTTLS|<span class="client_variables_available"> <code><span class="client_var_host"></span><span class="client_var_port"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|110|
-|POP3S|SSL|<span class="client_variables_available"> <code><span class="client_var_host"></span><span class="client_var_port"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|995|
-|SMTP|STARTTLS|<span class="client_variables_available"> <code><span class="client_var_host"></span><span class="client_var_port"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|587|
-|SMTPS|SSL|<span class="client_variables_available"> <code><span class="client_var_host"></span><span class="client_var_port"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|465|
+|IMAP|STARTTLS|<span class="client_variables_available"> <code><span class="client_var_host"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|143|
+|IMAPS|SSL|<span class="client_variables_available"> <code><span class="client_var_host"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|993|
+|POP3|STARTTLS|<span class="client_variables_available"> <code><span class="client_var_host"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|110|
+|POP3S|SSL|<span class="client_variables_available"> <code><span class="client_var_host"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|995|
+|SMTP|STARTTLS|<span class="client_variables_available"> <code><span class="client_var_host"></span></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|587|
+|SMTPS|SSL|<span class="client_variables_available"> <code><span class="client_var_host"></span></code></span><span class="client_variables_unavailable">mailcow hostname</span>|465|
 
 Please use "plain" as authentication mechanisms. Contrary to the assumption no passwords will be transfered plain text, as no authentication is allowed to take place without TLS.
 

--- a/docs/client/client-thunderbird.md
+++ b/docs/client/client-thunderbird.md
@@ -42,7 +42,7 @@
   Thunderbird briefly shows a message that it is updating extensions, then restarts automatically once more.
 </li>
 <li class="client_integrator_enabled">
-  When you are prompted to authenticate<span class="client_variables_available"> for <code><span class="client_var_host"></span><span class="client_var_port"></span></code></span>, enter your email address and password, check <i>Use Password Manager</i> and click <i>OK</i>.
+  When you are prompted to authenticate<span class="client_variables_available"> for <code><span class="client_var_host"></span></code></span>, enter your email address and password, check <i>Use Password Manager</i> and click <i>OK</i>.
 </li>
 </ol>
 

--- a/docs/clients.js
+++ b/docs/clients.js
@@ -3,12 +3,12 @@ if (window.location.href.indexOf('/client/') >= 0) {
         function setCookie(name, value) {
             document.cookie = encodeURIComponent(name) + "=" + encodeURIComponent(value) + "; path=/";
         }
-    
+
         function getParameterByName(name) {
             var match = RegExp('[?#&]' + name + '=([^&]*)').exec(window.location.hash);
             return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
         }
-    
+
         /* Store URL variables in cookies */
         if (getParameterByName('host')) {
             setCookie("host", getParameterByName('host'));
@@ -49,7 +49,7 @@ if (window.location.href.indexOf('/client') >= 0) {
             }
             return "";
         }
-    
+
         /* Hide variable fields if no values are available */
         if (!getCookie('host')) {
             Array.prototype.forEach.call(document.getElementsByClassName('client_variables_available'), function(el) {
@@ -60,12 +60,12 @@ if (window.location.href.indexOf('/client') >= 0) {
                 el.style.display = 'none';
             });
         }
-    
+
         /* Hide the TOC, which might contain hidden content */
         Array.prototype.forEach.call(document.getElementsByClassName('md-sidebar--secondary'), function(el) {
             el.style.display = 'none';
         });
-    
+
         /* Substitute variables */
         Array.prototype.forEach.call(document.getElementsByClassName('client_var_host'), function(el) {
             el.innerText = getCookie('host');
@@ -85,12 +85,7 @@ if (window.location.href.indexOf('/client') >= 0) {
         Array.prototype.forEach.call(document.getElementsByClassName('client_var_name'), function(el) {
             el.innerText = getCookie('name');
         });
-        if (getCookie('port') != '443') {
-            Array.prototype.forEach.call(document.getElementsByClassName('client_var_port'), function(el) {
-                el.innerText = ':' + getCookie('port');
-            });
-        }
-    
+
         /* Hide those sections that are not applicable because useOutlookForEAS is disabled or SOGo integrator is not available */
         if (getCookie('integrator')) {
             Array.prototype.forEach.call(document.getElementsByClassName('client_var_integrator_link'), function(el) {


### PR DESCRIPTION
If the mailcow UI isn't served via port 443 (as in the following example on port 4443) this custom port will be added to some manual pages.

1. It will be shown as a part of the host-address for manual configuration:
![manual](https://user-images.githubusercontent.com/5744732/51792827-69d7e880-21b7-11e9-8911-a0dd8444e91c.png)
2. And as part of the value for the host field for KDE Kontact:
![kontact](https://user-images.githubusercontent.com/5744732/51792834-82480300-21b7-11e9-98a9-b65c221b7942.png)
3. And somehow is supposed to show in a authentication dialog in thunderbird:
![thunderbird](https://user-images.githubusercontent.com/5744732/51792842-98ee5a00-21b7-11e9-9fd7-4e60eb65d2c1.png)
I don't see why the port is stated as a part of the mailserver-host-address, this PR therefore removes it from the manual pages. If it however makes sense to include the port, i would be happy about an explanation. 🙂
