### PR TITLE
hostname ≠ ui-domain

### DIFF
--- a/docs/clients.js
+++ b/docs/clients.js
@@ -3,12 +3,12 @@ if (window.location.href.indexOf('/client/') >= 0) {
         function setCookie(name, value) {
             document.cookie = encodeURIComponent(name) + "=" + encodeURIComponent(value) + "; path=/";
         }
-    
+
         function getParameterByName(name) {
             var match = RegExp('[?#&]' + name + '=([^&]*)').exec(window.location.hash);
             return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
         }
-    
+
         /* Store URL variables in cookies */
         if (getParameterByName('host')) {
             setCookie("host", getParameterByName('host'));
@@ -20,6 +20,9 @@ if (window.location.href.indexOf('/client/') >= 0) {
         }
         if (getParameterByName('name')) {
             setCookie("name", getParameterByName('name'));
+        }
+        if (getParameterByName('ui')) {
+            setCookie("ui", getParameterByName('ui'));
         }
         if (getParameterByName('port')) {
             setCookie("port", getParameterByName('port'));
@@ -49,7 +52,7 @@ if (window.location.href.indexOf('/client') >= 0) {
             }
             return "";
         }
-    
+
         /* Hide variable fields if no values are available */
         if (!getCookie('host')) {
             Array.prototype.forEach.call(document.getElementsByClassName('client_variables_available'), function(el) {
@@ -60,23 +63,23 @@ if (window.location.href.indexOf('/client') >= 0) {
                 el.style.display = 'none';
             });
         }
-    
+
         /* Hide the TOC, which might contain hidden content */
         Array.prototype.forEach.call(document.getElementsByClassName('md-sidebar--secondary'), function(el) {
             el.style.display = 'none';
         });
-    
+
         /* Substitute variables */
         Array.prototype.forEach.call(document.getElementsByClassName('client_var_host'), function(el) {
             el.innerText = getCookie('host');
         });
         Array.prototype.forEach.call(document.getElementsByClassName('client_var_link'), function(el) {
-            if (!getCookie('host')) {
+            if (!getCookie('ui')) {
                 el.href = '#';
             } else if (getCookie('port') != '443') {
-                el.href = 'https://' + getCookie('host') + ':' + getCookie('port') + '/' + el.getAttribute("href");
+                el.href = 'https://' + getCookie('ui') + ':' + getCookie('port') + '/' + el.getAttribute("href");
             } else {
-                el.href = 'https://' + getCookie('host') + '/' + el.getAttribute("href");
+                el.href = 'https://' + getCookie('ui') + '/' + el.getAttribute("href");
             }
         });
         Array.prototype.forEach.call(document.getElementsByClassName('client_var_email'), function(el) {
@@ -90,7 +93,7 @@ if (window.location.href.indexOf('/client') >= 0) {
                 el.innerText = ':' + getCookie('port');
             });
         }
-    
+
         /* Hide those sections that are not applicable because useOutlookForEAS is disabled or SOGo integrator is not available */
         if (getCookie('integrator')) {
             Array.prototype.forEach.call(document.getElementsByClassName('client_var_integrator_link'), function(el) {

--- a/docs/clients.js
+++ b/docs/clients.js
@@ -74,12 +74,15 @@ if (window.location.href.indexOf('/client') >= 0) {
             el.innerText = getCookie('host');
         });
         Array.prototype.forEach.call(document.getElementsByClassName('client_var_link'), function(el) {
-            if (!getCookie('ui')) {
+            if (!getCookie('ui') && !getCookie('host')) {
                 el.href = '#';
-            } else if (getCookie('port') != '443') {
-                el.href = 'https://' + getCookie('ui') + ':' + getCookie('port') + '/' + el.getAttribute("href");
             } else {
-                el.href = 'https://' + getCookie('ui') + '/' + el.getAttribute("href");
+                var ui_domain = getCookie('ui') ? getCookie('ui') : getCookie('host');
+                if (getCookie('port') != '443') {
+                    el.href = 'https://' + ui_domain + ':' + getCookie('port') + '/' + el.getAttribute("href");
+                } else {
+                    el.href = 'https://' + ui_domain + '/' + el.getAttribute("href");
+                }
             }
         });
         Array.prototype.forEach.call(document.getElementsByClassName('client_var_email'), function(el) {


### PR DESCRIPTION
We need a additional variable for the mailcow-ui-domain, if the domain used for the mailcow ui differs from the hostname. Otherwise our users will get the login promt, when they try to access the mobileconfig file.
The mailcow-ui-domain will be passed on from the mailcow-ui, if the corresponding PR gets merged: https://github.com/mailcow/mailcow-dockerized/pull/2229