### PR TITLE
Updating u_e-webmail-site.md

### DIFF
--- a/docs/u_e-webmail-site.md
+++ b/docs/u_e-webmail-site.md
@@ -12,6 +12,7 @@ server {
   include /etc/nginx/conf.d/listen_ssl.active;
   server_name webmail.example.org;
 
+  root /web;
   location ^~ /.well-known/acme-challenge/ {
     allow all;
     default_type "text/plain";


### PR DESCRIPTION
 - added: root directive to enable acme
   Otherwise nginx's default location (/etc/nginx/html/) is tried for
   the acme challenge.