### PR TITLE
add missing ipv6 configuration for nginx SSL example

### DIFF
--- a/docs/firststeps-rp.md
+++ b/docs/firststeps-rp.md
@@ -113,6 +113,7 @@ server {
 }
 server {
   listen 443;
+  listen [::]:443;
   server_name CHANGE_TO_MAILCOW_HOSTNAME autodiscover.* autoconfig.*;
 
   ssl on;


### PR DESCRIPTION
fixes https://github.com/mailcow/mailcow-dockerized/issues/2658