### PR TITLE
Update i_u_m_install.md

### DIFF
--- a/docs/i_u_m_install.md
+++ b/docs/i_u_m_install.md
@@ -4,7 +4,7 @@
 
 You need Docker and Docker Compose.
 
-**1\.** Learn how to install [Docker](https://docs.docker.com/engine/installation/linux/) and [Docker Compose](https://docs.docker.com/compose/install/).
+**1\.** Learn how to install [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
 
 Quick installation for most operation systems:
 


### PR DESCRIPTION
The URL of Docker Install has been changed from https://docs.docker.com/engine/installation/linux/ to https://docs.docker.com/install/

I think this is their way of putting all possible means to install Docker in one URL. 
Although the old link redirects pretty neatly, I feel it's best the URL is updated to reflect the new one to avoid a broken link later on.