### PR TITLE
Create note for forece ckecking recipient domains for existence

### DIFF
--- a/docs/u_e-postfix-force-check-recipient-domain-for-existence.md
+++ b/docs/u_e-postfix-force-check-recipient-domain-for-existence.md
@@ -1,7 +1,10 @@
+The following setting can be useful when having a relay domain and not every user of that user domain has a extra user created on mailcow site.
+The problem without this setting is more specified in https://github.com/mailcow/mailcow-dockerized/issues/2981
+
 Open `data/conf/postfix/main.cf` and add `reject_unverified_recipient` to ```smtpd_recipient_restrictions```. For example:
 
 ```
-smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, check_recipient_access proxy:mysql:/opt/postfix/conf/sql/mysql_tls_enforce_in_policy.cf, reject_invalid_helo_hostname, reject_unknown_reverse_client_hostname, reject_unauth_destination, reject_unverified_recipient
+smtpd_recipient_restrictions = permit_sasl_authenticated, [...], reject_unauth_destination, reject_unverified_recipient
 ```
 
 Restart Postfix:

--- a/docs/u_e-postfix-force-check-recipient-domain-for-existence.md
+++ b/docs/u_e-postfix-force-check-recipient-domain-for-existence.md
@@ -1,0 +1,11 @@
+Open `data/conf/postfix/main.cf` and add `reject_unverified_recipient` to ```smtpd_recipient_restrictions```. For example:
+
+```
+smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, check_recipient_access proxy:mysql:/opt/postfix/conf/sql/mysql_tls_enforce_in_policy.cf, reject_invalid_helo_hostname, reject_unknown_reverse_client_hostname, reject_unauth_destination, reject_unverified_recipient
+```
+
+Restart Postfix:
+
+```
+docker-compose restart postfix-mailcow
+```


### PR DESCRIPTION
In my use case, this is needed when the recipient domain is a relay domain.

More explained in https://github.com/mailcow/mailcow-dockerized/issues/2981

Since there could be more problems when this setting would be a default, so here just a note