### PR TITLE
Made docs more concrete

### DIFF
--- a/docs/client/client-apple.md
+++ b/docs/client/client-apple.md
@@ -1,6 +1,6 @@
 ## Method 1 via Mobileconfig
 
-Email, contacts and calendars can be configured automatically on Apple devices by installing a profile.
+Email, contacts and calendars can be configured automatically on Apple devices by installing a profile. To download a profile you must login to the Mailcow UI first.
 
 ## Method 1.1: IMAP, SMTP and Cal/CardDAV
 

--- a/docs/client/client-apple.md
+++ b/docs/client/client-apple.md
@@ -1,6 +1,6 @@
 ## Method 1 via Mobileconfig
 
-Email, contacts and calendars can be configured automatically on Apple devices by installing a profile. To download a profile you must login to the Mailcow UI first.
+Email, contacts and calendars can be configured automatically on Apple devices by installing a profile. To download a profile you must login to the mailcow UI first.
 
 ## Method 1.1: IMAP, SMTP and Cal/CardDAV
 


### PR DESCRIPTION
To get access to the profile for Apple devices the user must be logged in into the Mailcow UI with the mailbox user account he wants to add to his device.