### PR TITLE
Fix syntax highlighting in docs

### DIFF
--- a/docs/u_e-rspamd.md
+++ b/docs/u_e-rspamd.md
@@ -14,7 +14,8 @@ You can also use Rspamd's web UI to learn ham and / or spam or to adjust certain
 ### Learn Spam or Ham from existing directory
 
 You can use a one-liner to learn mail in plain-text (uncompressed) format:
-```
+
+```bash
 # Ham
 for file in /my/folder/cur/*; do docker exec -i $(docker-compose ps -q rspamd-mailcow) rspamc learn_ham < $file; done
 # Spam
@@ -23,7 +24,7 @@ for file in /my/folder/.Junk/cur/*; do docker exec -i $(docker-compose ps -q rsp
 
 Consider attaching a local folder as new volume to `rspamd-mailcow` in `docker-compose.yml` and learn given files inside the container. This can be used as workaround to parse compressed data with zcat. Example:
 
-```
+```bash
 for file in /data/old_mail/.Junk/cur/*; do rspamc learn_spam < zcat $file; done
 ```
 
@@ -32,27 +33,31 @@ for file in /data/old_mail/.Junk/cur/*; do rspamc learn_spam < zcat $file; done
 You need to delete keys in Redis to reset learned mail, so create a copy of your Redis database now:
 
 **Backup database**
-```
+
+```bash
 # It is better to stop Redis before you copy the file.
 cp /var/lib/docker/volumes/mailcowdockerized_redis-vol-1/_data/dump.rdb /root/
 ```
 
 **Reset Bayes data**
-```
+
+```bash
 docker-compose exec redis-mailcow sh -c 'redis-cli --scan --pattern BAYES_* | xargs redis-cli del'
 docker-compose exec redis-mailcow sh -c 'redis-cli --scan --pattern RS* | xargs redis-cli del'
 ```
 
 If it complains about...
-```
+
+```text
 (error) ERR wrong number of arguments for 'del' command
 ```
+
 ...the key pattern was not found and thus no data is available to delete.
 
 
 ## CLI tools
 
-```
+```bash
 docker-compose exec rspamd-mailcow rspamc --help
 docker-compose exec rspamd-mailcow rspamadm --help
 ```
@@ -65,7 +70,9 @@ You can disable rspamd's greylisting server-wide by editing:
 
 Simply add the line:
 
-`enabled = false;`
+```cpp
+enabled = false;
+```
 
 Save the file and then restart the rspamd container.
 
@@ -75,17 +82,25 @@ See [Rspamd documentation](https://rspamd.com/doc/index.html)
 
 You may find that legitimate (clean) mail is being blocked by ClamAV (Rspamd will flag the mail with `VIRUS_FOUND`). For instance, interactive PDF form attachments are blocked by default because the embedded Javascript code may be used for nefarious purposes. Confirm by looking at the clamd logs, e.g.:
 
-`docker-compose logs clamd-mailcow | grep FOUND`
+```bash
+docker-compose logs clamd-mailcow | grep "FOUND"
+```
 
 This line confirms that such was identified:
 
-`clamd-mailcow_1      | Sat Sep 28 07:43:24 2019 -> instream(local): PUA.Pdf.Trojan.EmbeddedJavaScript-1(e887d2ac324ce90750768b86b63d0749:363325) FOUND`
+```text
+clamd-mailcow_1      | Sat Sep 28 07:43:24 2019 -> instream(local): PUA.Pdf.Trojan.EmbeddedJavaScript-1(e887d2ac324ce90750768b86b63d0749:363325) FOUND
+```
 
 To whitelist this particular signature (and enable sending this type of file attached), add it to the ClamAV signature whitelist file:
 
-`echo 'PUA.Pdf.Trojan.EmbeddedJavaScript-1' >> data/conf/clamav/whitelist.ign2`
+```bash
+echo 'PUA.Pdf.Trojan.EmbeddedJavaScript-1' >> data/conf/clamav/whitelist.ign2
+```
 
 Then restart the clamd-mailcow service container in the mailcow UI, or using docker-compose:
 
-`docker-compose restart clamd-mailcow`
+```bash
+docker-compose restart clamd-mailcow
+```
 


### PR DESCRIPTION
Fixes presentation: https://mailcow.github.io/mailcow-dockerized-docs/u_e-rspamd/