### PR TITLE
Update IPv6 related docs

### DIFF
--- a/docs/firststeps-disable_ipv6.md
+++ b/docs/firststeps-disable_ipv6.md
@@ -1,4 +1,4 @@
-This is **ONLY** recommended if you do not have an IPv6 enabled network!
+This is **ONLY** recommended if you do not have an IPv6 enabled network on your host!
 
 If IPv6 MUST be disabled to fit a network, open `docker-compose.yml`, search for `enable_ipv6`...
 

--- a/docs/firststeps-disable_ipv6.md
+++ b/docs/firststeps-disable_ipv6.md
@@ -1,4 +1,4 @@
-This is **NOT** recommended!
+This is **ONLY** recommended if you do not have an IPv6 enabled network!
 
 If IPv6 MUST be disabled to fit a network, open `docker-compose.yml`, search for `enable_ipv6`...
 

--- a/docs/i_u_m_install.md
+++ b/docs/i_u_m_install.md
@@ -48,7 +48,11 @@ You may need to stop an existing pre-installed MTA which blocks port 25/tcp. See
 
 Some updates modify mailcow.conf and add new parameters. It is hard to keep track of them in the documentation. Please check their description and, if unsure, ask at the known channels for advise.
 
-**4\.1\.** Users with a MTU not equal to 1500 (e.g. OpenStack):
+**4\.1\.** Users without a IPv6 enabled network:
+
+**If you do not have an IPv6 enabled network it is recommended to [disable IPv6](https://mailcow.github.io/mailcow-dockerized-docs/firststeps-disable_ipv6/) for the mailcow stack to prevent unforeseen issues.**
+
+**4\.2\.** Users with a MTU not equal to 1500 (e.g. OpenStack):
 
 **Whenever you run into trouble and strange phenomena, please check your MTU.**
 

--- a/docs/i_u_m_install.md
+++ b/docs/i_u_m_install.md
@@ -48,11 +48,7 @@ You may need to stop an existing pre-installed MTA which blocks port 25/tcp. See
 
 Some updates modify mailcow.conf and add new parameters. It is hard to keep track of them in the documentation. Please check their description and, if unsure, ask at the known channels for advise.
 
-**4\.1\.** Users without a IPv6 enabled network:
-
-**If you do not have an IPv6 enabled network it is recommended to [disable IPv6](https://mailcow.github.io/mailcow-dockerized-docs/firststeps-disable_ipv6/) for the mailcow stack to prevent unforeseen issues.**
-
-**4\.2\.** Users with a MTU not equal to 1500 (e.g. OpenStack):
+**4\.1\.** Users with a MTU not equal to 1500 (e.g. OpenStack):
 
 **Whenever you run into trouble and strange phenomena, please check your MTU.**
 
@@ -66,6 +62,13 @@ networks:
       com.docker.network.driver.mtu: 1450
     ...
 ```
+
+**4\.2\.** Users without an IPv6 enabled network on their host system:
+
+**Enable IPv6. Finally.**
+
+If you do not have an IPv6 enabled network on your host and you don't care for a better internet (thehe), it is recommended to [disable IPv6](https://mailcow.github.io/mailcow-dockerized-docs/firststeps-disable_ipv6/) for the mailcow network to prevent unforeseen issues.
+
 
 **5\.** Pull the images and run the composer file. The parameter `-d` will start mailcow: dockerized detached:
 ```


### PR DESCRIPTION
This updates the documentation for recommendations if the user is not running no an IPv6 enabled network/host and also adjusts the wording for disabling IPv6 to be more explicit.

Related to: https://github.com/mailcow/mailcow-dockerized/issues/3168.