### PR TITLE
Update migration guide to use Admonition plugin and some small fixes

### DIFF
--- a/docs/i_u_m_migration.md
+++ b/docs/i_u_m_migration.md
@@ -1,6 +1,8 @@
-#### Please note: This guide assumes you intend to migrate an existing mailcow server (source) over to a brand new, empty server (target). It takes no care about preserving any existing data on your target server and will erase anything within `/var/lib/docker/volumes` and thus any Docker volumes you may have already set up.
+!!! warning
+    Please note: This guide assumes you intend to migrate an existing mailcow server (source) over to a brand new, empty server (target). It takes no care about preserving any existing data on your target server and will erase anything within `/var/lib/docker/volumes` and thus any Docker volumes you may have already set up.
 
-##### Alternatively, you can use the `./helper-scripts/backup_and_restore.sh` script to create a full backup on the source machine, then install mailcow on the target machine as usual, copy over your `mailcow.conf` and use the same script to restore your backup to the target machine.
+!!! tip
+    Alternatively, you can use the `./helper-scripts/backup_and_restore.sh` script to create a full backup on the source machine, then install mailcow on the target machine as usual, copy over your `mailcow.conf` and use the same script to restore your backup to the target machine.
 
 **1\.** 
 Install [Docker](https://docs.docker.com/engine/installation/linux/) and [Docker Compose](https://docs.docker.com/compose/install/) on your new server.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: "mailcow: dockerized documentation"
 site_url: https://mailcow.github.io/mailcow-dockerized-docs/
-copyright: 'Copyright &copy; 2019 André Peters'
+copyright: 'Copyright &copy; 2020 André Peters'
 repo_name: mailcow/mailcow-dockerized
 repo_url: https://github.com/mailcow/mailcow-dockerized
 edit_uri: ../mailcow-dockerized-docs/edit/master/docs/
@@ -119,7 +119,7 @@ extra:
     accent: 'orange'
   social:
     - type: globe
-      link: http://mailcow.email
+      link: https://mailcow.email
     - type: github-alt
       link: https://github.com/mailcow
 extra_css: [extra.css]


### PR DESCRIPTION
Migration guide looks like this now:
![image](https://user-images.githubusercontent.com/3279213/71647392-b0529300-2cf6-11ea-8801-c3476a961b6d.png)
