### PR TITLE
Update rewriterule for Apache to get Letsencrypt working

### DIFF
--- a/docs/firststeps-rp.md
+++ b/docs/firststeps-rp.md
@@ -48,6 +48,7 @@ Let's Encrypt will follow our rewrite, certificate requests in mailcow will work
   RewriteEngine on
 
   RewriteCond %{HTTPS} !=on
+  RewriteCond %{THE_REQUEST} !\s/+(/.well-known/*)\s [NC]
   RewriteRule ^/?(.*) https://%{HTTP_HOST}/$1 [R=301,L]
 
   ProxyPass / http://127.0.0.1:8080/


### PR DESCRIPTION
The rewrite rule only checked for non https and then rewrote every request to https. Letsencrypt checks use http only so we have to let them stay on http and not rewrite them to https.