### PR TITLE
Added missing port in netstat command

### DIFF
--- a/docs/prerequisite-system.md
+++ b/docs/prerequisite-system.md
@@ -31,7 +31,7 @@ ClamAV and Solr are greedy RAM munchers. You can disable them in `mailcow.conf` 
 Please check if any of mailcow's standard ports are open and not in use by other applications:
 
 ```
-# netstat -tulpn | grep -E -w '25|80|110|143|443|465|587|993|995'
+# netstat -tulpn | grep -E -w '25|80|110|143|443|465|587|993|995|4190'
 ```
 
 !!! warning


### PR DESCRIPTION
In the netstat command for checking the standard-ports the port for "Dovecot ManageSieve" was missing