### PR TITLE
Added instructions for the Nine E-Mail app

### DIFF
--- a/docs/client/client-android.md
+++ b/docs/client/client-android.md
@@ -1,3 +1,20 @@
+# Nine E-Mail Client
+
+**NOTE:** We have no affiliation with 9Folders Inc. We only found this client to work very well with mailcow.  
+**NOTE:** This app requires a one time purchase of 14.99€ **after the free trial.**
+
+1. Download the Nine App from Google Play: https://play.google.com/store/apps/details?id=com.ninefolders.hd3
+2. Open the Nine App
+3. Press "First Steps"
+4. Enter your E-Mail address and press "Continue"
+5. After the loading period, it will ask you what type of account it is. Press "Exchange-Server or others"
+6. Enter your password and press "Manual Setup"
+7. Check if the field "Server" has the correct address (e.g. `mail.example.com`), correct it if necessary and press "Continue"
+8. Select what you want to be synchronized by tapping the icon and press "Continue" when you're done
+9. Give your Account an optional name, check the settings and press "Continue"
+
+# Generic
+
 1. Open the *Email* app.
 2. If this is your first email account, tap *Add Account*; if not, tap *More* and *Settings* and then *Add account*.
 3. Select *Microsoft Exchange ActiveSync*.


### PR DESCRIPTION
I did this because this is the only Android app which allows you to see calendar categories which can be synced with the server.
I added a disclaimer saying that mailcow is not affiliated with the company which produces the app and explaining that it's found to work properly and that's all. Feel free to edit this in any way you see fit.