### PR TITLE
Upgrade mkdocs-material to 5.x

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,15 +118,16 @@ nav:
   - 'Gogs': 'third_party-gogs.md'
   - 'Gitea': 'third_party-gitea.md'
   - 'Nextcloud': 'third_party-nextcloud.md'
-extra:
+icon:
   logo: 'images/logo.svg'
+extra:
   palette:
     primary: 'indigo'
     accent: 'orange'
   social:
-    - type: globe
+    - icon: fontawesome/solid/globe-americas
       link: https://mailcow.email
-    - type: github-alt
+    - icon: fontawesome/brands/github-alt
       link: https://github.com/mailcow
 extra_css: [extra.css]
 extra_javascript: [clients.js]


### PR DESCRIPTION
We needed to modify mkdocs.yml due to new release of [mkdocs](https://www.mkdocs.org/about/release-notes/) and mkdocs-materials major release and[ its changes](https://squidfunk.github.io/mkdocs-material/releases/5/#how-to-upgrade) which breaks Travis-CI builds and deploys