### PR TITLE
Mention lz4 compression in u_e-dovecot-mail-crypt.md #2754, #2337

### DIFF
--- a/docs/u_e-dovecot-mail-crypt.md
+++ b/docs/u_e-dovecot-mail-crypt.md
@@ -1,4 +1,4 @@
-Mails are stored encrypted, the key pair can be found in crypt-vol-1.
+Mails are stored compressed (lz4) and encrypted. The key pair can be found in crypt-vol-1.
 
 If you want to decode/encode existing maildir files, you can use the following script at your own risk:
 
@@ -8,7 +8,7 @@ Enter Dovecot by running `docker-compose exec dovecot-mailcow /bin/bash` in the 
 # Decrypt /var/vmail
 find /var/vmail/ -type f -regextype egrep -regex '.*S=.*W=.*' | while read -r file; do
 if [[ $(head -c7 "$file") == "CRYPTED" ]]; then
-doveadm fs get crypt private_key_path=/mail_crypt/ecprivkey.pem:public_key_path=/mail_crypt/ecpubkey.pem:posix:prefix=/ \
+doveadm fs get compress lz4:0:crypt:private_key_path=/mail_crypt/ecprivkey.pem:public_key_path=/mail_crypt/ecpubkey.pem:posix:prefix=/ \
   "$file" > "/tmp/$(basename "$file")"
   if [[ -s "/tmp/$(basename "$file")" ]]; then
     chmod 600 "/tmp/$(basename "$file")"


### PR DESCRIPTION
I found two issues (#2754, #2337) discribing problems with unreadable files after decryption. This is caused by the compression with lz4.
By mentioning this in the documentation it could be easier for other users.