### PR TITLE
typo: Change `role` to `roll`.

### DIFF
--- a/docs/i_u_m_update.md
+++ b/docs/i_u_m_update.md
@@ -52,7 +52,7 @@ dacd4fb9b51e9e1c8a37d84485b92ffaf6c59353 Before update on 2020-08-07_13_31_31
 
 Run `git diff 22cd00b5e28893ef9ddef3c2b5436453cc5223ab` to see what changed.
 
-### Can I role back?
+### Can I roll back?
 
 Yes.
 


### PR DESCRIPTION
# Summary

This pull request fixes a typo.