### PR TITLE
Update `pip install` command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ https://mailcow.github.io/mailcow-dockerized-docs
 To build it locally, you need the [Material theme for MkDocs](https://squidfunk.github.io/mkdocs-material/), [MkDocs](https://www.mkdocs.org/) itself and [Pygments](http://pygments.org/). To install these with [pip](https://pip.pypa.io/en/stable/) and get it up and running, fire up your terminal and enter
 
 ```
-pip install mkdocs-material
+pip install mkdocs-material pygments==2.8.1 mkdocs-redirects
 mkdocs serve
 ```


### PR DESCRIPTION
Just installing `mkdocs-material` isn't sufficient. I copied the `pip install` command from the GitHub Actions config.