### PR TITLE
Document maildir_very_dirty_syncs

### DIFF
--- a/docs/u_e-dovecot-perf.md
+++ b/docs/u_e-dovecot-perf.md
@@ -2,7 +2,7 @@
 
 Dovecot's [`maildir_very_dirty_syncs` option](https://wiki.dovecot.org/MailLocation/Maildir#Optimizations) is enabled by default. This option can significantly improve the performance of mailboxes that contain very large folders (over 100,000 emails).
 
-What this option does is it avoids rescanning the entire `cur` directory whenever loading an email. With this option disabled, Dovecot takes it safe and scans the **entire** `cur` directory (essentially running an `ls`) to check if that particular email was touched (renamed, etc), by looking for all files whose names contain the correct ID. This is very slow if the directory is large, even on filesystems optimized for such use cases (such as ext4 with `dir_index` enabled) on fast SSD drives.
+What this option does is it avoids rescanning the entire `cur` directory whenever loading an email. With this option disabled, Dovecot takes it safe and scans the **entire** `cur` directory (comparable with running an `ls`) to check if that particular email was touched (renamed, etc), by looking for all files whose names contain the correct ID. This is very slow if the directory is large, even on filesystems optimized for such use cases (such as ext4 with `dir_index` enabled) on fast SSD drives.
 
 This option is safe to use as long as you do not manually touch files under `cur` (as then Dovecot may not notice the changes). Even with this option enabled, Dovecot will still notice changes if the file's mtime (last modified time) is changed, but otherwise it will not scan the directory and just assumes the index is up-to-date. This is essentially the same as what sdbox/mdbox do, and with this option you can get some of the performance increase that would come with sdbox/mdbox while still using maildir.
 

--- a/docs/u_e-dovecot-perf.md
+++ b/docs/u_e-dovecot-perf.md
@@ -1,0 +1,13 @@
+## maildir_very_dirty_syncs
+
+Dovecot's [`maildir_very_dirty_syncs` option](https://wiki.dovecot.org/MailLocation/Maildir#Optimizations) is enabled by default. This option can significantly improve the performance of mailboxes that contain very large folders (over 100,000 emails).
+
+What this option does is it avoids rescanning the entire `cur` directory whenever loading an email. With this option disabled, Dovecot takes it safe and scans the **entire** `cur` directory (essentially running an `ls`) to check if that particular email was touched (renamed, etc), by looking for all files whose names contain the correct ID. This is very slow if the directory is large, even on filesystems optimized for such use cases (such as ext4 with `dir_index` enabled) on fast SSD drives.
+
+This option is safe to use as long as you do not manually touch files under `cur` (as then Dovecot may not notice the changes). Even with this option enabled, Dovecot will still notice changes if the file's mtime (last modified time) is changed, but otherwise it will not scan the directory and just assumes the index is up-to-date. This is essentially the same as what sdbox/mdbox do, and with this option you can get some of the performance increase that would come with sdbox/mdbox while still using maildir.
+
+This option is safe to use on a standard Mailcow installation. However, if you use any third-party tools that manually modify files directly in the maildir (rather than via IMAP), you may wish to disable it. To disable this option, [create a data/conf/dovecot/extra.conf file](u_e-dovecot-extra_conf.md) and add this setting to it:
+
+```ini
+maildir_very_dirty_syncs=no
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
   - 'Unbound':
     - 'Using an external DNS service': 'u_e-unbound-fwd.md'
   - 'Dovecot':
+    - 'Performance Optimizations': 'u_e-dovecot-perf.md'
     - 'Enable "any" ACL settings': 'u_e-dovecot-any_acl.md'
     - 'Expunge a Users mails': 'u_e-dovecot-expunge.md'
     - 'Customize/Expand dovecot.conf': 'u_e-dovecot-extra_conf.md'


### PR DESCRIPTION
Created a documentation page about `maildir_very_dirty_syncs`. I named it "Dovecot Performance Optimizations" so other performance-related settings could be documented there too.

Screenshot:
![image](https://user-images.githubusercontent.com/91933/116831489-8fa58200-ab64-11eb-85e5-6a9e584f4292.png)


References https://github.com/mailcow/mailcow-dockerized/pull/4028