### PR TITLE
Dovecot default realm

### DIFF
--- a/docs/u_e-dovecot-default_relam.md
+++ b/docs/u_e-dovecot-default_relam.md
@@ -1,0 +1,15 @@
+By default, mailcow expects the username for authentication to include the realm (domain name). To allow for ease of migration from a platform that does not use the realm, you can set a default realm. Dovecot will append this domain to any username that does not have a realm supplied. 
+
+To change this default, you need to make changes in the data/conf/dovecot/extra.cf:
+
+``` data/conf/dovecot/extra.cf
+auth_default_realm = schwetz.com.au
+```
+Following this change, you will need to restart the dovecot container:
+
+``` shell
+docker-compose restart dovecot-mailcow
+```
+
+!!! Note
+Authentication with SOGo will still require the e-mail address

--- a/docs/u_e-dovecot-default_relam.md
+++ b/docs/u_e-dovecot-default_relam.md
@@ -1,4 +1,4 @@
-By default, mailcow expects the username for authentication to include the realm (domain name). To allow for ease of migration from a platform that does not use the realm, you can set a default realm. Dovecot will append this domain to any username that does not have a realm supplied. 
+By default, mailcow expects the username for authentication to include the realm (domain name). To allow for ease of migration from a platform that does not use a realm, you can set a default realm. Dovecot will append this domain to any username that does not have a realm supplied. 
 
 To change this default, you need to make changes in the data/conf/dovecot/extra.cf:
 


### PR DESCRIPTION
Explains how to set a default domain on dovecot to use if realm not supplied