### PR TITLE
fix a small typo in the xmpp FAQ

### DIFF
--- a/docs/u_e-xmpp-faq.md
+++ b/docs/u_e-xmpp-faq.md
@@ -68,7 +68,7 @@ No, they will vanish:
 
 - **How many client sessions can be open at the same time?**
 
-10 sessions are allowed per session.
+10 sessions are allowed per user.
 
 ```
 shaper_rules:


### PR DESCRIPTION
There's a small typo in the section about the maximum allowed sessions