### PR TITLE
Remove infinite redirect

### DIFF
--- a/docs/firststeps-rp.md
+++ b/docs/firststeps-rp.md
@@ -58,7 +58,7 @@ Let's Encrypt will follow our rewrite, certificate requests in mailcow will work
   RewriteEngine on
 
   RewriteCond %{HTTPS} off
-  RewriteRule ^/?(.*) https://%{HTTP_HOST}/$1 [R=301,L]
+  
 
   ProxyPass / http://127.0.0.1:8080/
   ProxyPassReverse / http://127.0.0.1:8080/


### PR DESCRIPTION
Was having issues with infinite redirects, commenting out 
RewriteRule ^/?(.*) https://%{HTTP_HOST}/$1 [R=301,L]
[line61] seemed to fix the issue, and continues to redirect the http to https