### PR TITLE
Small tweaks to prerequisite-dns.md

### DIFF
--- a/docs/prerequisite-dns.md
+++ b/docs/prerequisite-dns.md
@@ -90,7 +90,7 @@ If you are interested in statistics, you can additionally register with some of 
 !!! Tip
 It is worth considering that if you request DMARC statistic reports to your mailcow server and your mailcow server is not configured correctly to receive these reports, you may not get accurate and complete results. Please consider using an alternative email domain for receiving DMARC reports.
 
-It is worth mentioning, that the following suggestions are not a comprehensive list of all services and tools avaialble, but only a small few of the many choices.
+It is worth mentioning, that the following suggestions are not a comprehensive list of all services and tools available, but only a small few of the many choices.
 
 - [Postmaster Tool](https://gmail.com/postmaster)
 - [parsedmarc](https://github.com/domainaware/parsedmarc) (self-hosted)
@@ -100,7 +100,7 @@ It is worth mentioning, that the following suggestions are not a comprehensive l
 
 !!! Tip
 
-These services may provide you with a TXT record you need to insert into your DNS records as the provider specifies. Please ensure to read the providers documentation from the service you choose as this process may vary.
+These services may provide you with a TXT record you need to insert into your DNS records as the provider specifies. Please ensure you read the provider's documentation from the service you choose as this process may vary.
 
 ### Email test for SPF, DKIM and DMARC:
 
@@ -127,4 +127,4 @@ The full report will contain more technical details.
 
 ### Fully Qualified Domain Name (FQDN)
 
-[^1]: A **Fully Qualified Domain Name** (**FQDN**) is the complete (absolute) domain name for a specific computer or host, on the Internet. The FQDN consists of at least three parts divided by a dot: the hostname (myhost), the domain name (mydomain) and the top level domain in short **tld** (com). In the example of `mx.mailcow.email` the hostname would be `mx`, the domain name `mailcow` and the tld `email`.
+[^1]: A **Fully Qualified Domain Name** (**FQDN**) is the complete (absolute) domain name for a specific computer or host, on the Internet. The FQDN consists of at least three parts divided by a dot: the hostname, the domain name, and the Top Level Domain (**TLD** for short). In the example of `mx.mailcow.email` the hostname would be `mx`, the domain name `mailcow` and the TLD `email`.


### PR DESCRIPTION
- Typo fix: "avaialble" → "available"
- Grammar fix: "Please ensure to read the providers documentation" → "Please ensure you read the provider's documentation"
- Reworded the FQDN section a bit. The `myhost.mydomain.com` examples aren't really necessary given the next sentence uses `mx.mailcow.email` as an example.