### PR TITLE
Update link to Solr

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ Each container represents a single application.
 - [Redis](https://redis.io/)
 - [Rspamd](https://www.rspamd.com/)
 - [SOGo](https://sogo.nu/)
-- [Solr](http://lucene.apache.org/solr/) (optional)
+- [Solr](https://solr.apache.org/) (optional)
 - [Unbound](https://unbound.net/)
 - A Watchdog to provide basic monitoring
 


### PR DESCRIPTION
Solr has become a Apache Software Foundation Top Level Project (TLP) on 17 February 2021.
This means it moved from being a sub of lucene http://lucene.apache.org/solr/  to a new website.
See https://web.archive.org/web/20210424020503/https://solr.apache.org/news.html#apache-solr-becomes-an-apache-tlp