### PR TITLE
add /opt/mailcow-dockerized to borgmatic example

### DIFF
--- a/docs/third_party-borgmatic.md
+++ b/docs/third_party-borgmatic.md
@@ -30,6 +30,7 @@ services:
     dns: ${IPV4_NETWORK:-172.22.1}.254
     volumes:
       - vmail-vol-1:/mnt/source/vmail:ro
+      - /opt/mailcow-dockerized:/mnt/source/mailcow-dockerized:ro
       - mysql-socket-vol-1:/var/run/mysqld/:z
       - ./data/conf/borgmatic/etc:/etc/borgmatic.d:Z
       - ./data/conf/borgmatic/state:/root/.config/borg:Z


### PR DESCRIPTION
Hi,
to backup modifications on mailcow.conf (and more, like nginx redirects, roundcube...) /opt/mailcow-dockerized should be part of the backup too.

