### PR TITLE
Update Roundcube guide for 1.5 release and upgrade

### DIFF
--- a/docs/third_party-roundcube.md
+++ b/docs/third_party-roundcube.md
@@ -6,7 +6,8 @@ Download Roundcube 1.5.x to the web htdocs directory and extract it (here `rc/`)
 cd data/web
 wget -O - https://github.com/roundcube/roundcubemail/releases/download/1.5.0/roundcubemail-1.5.0-complete.tar.gz | tar xfvz -
 # Change folder name
-mv roundcubemail-1.5-rc rc
+mv roundcubemail-1.5.0 rc
+
 # Change permissions
 chown -R root: rc/
 ```


### PR DESCRIPTION
Update Roundcube guide for 1.5 release, then added simple upgrade instructions, for people with older installs.

Pretty much a copy and paste upgrade example, for users to follow.