### PR TITLE
Revert "Update third_party-roundcube.md"

### DIFF
--- a/docs/third_party-roundcube.md
+++ b/docs/third_party-roundcube.md
@@ -67,8 +67,6 @@ Initialize the database and leave the installer.
 
 Open `data/web/rc/plugins/managesieve/config.inc.php` and change the following parameters (or add them at the bottom of that file):
 ```
-//Make sure you have <?php at the beginning of the file or add just like below
-<?php 
 $config['managesieve_port'] = 4190;
 $config['managesieve_host'] = 'tls://dovecot';
 $config['managesieve_conn_options'] = array(


### PR DESCRIPTION
Reverts mailcow/mailcow-dockerized-docs#317

Why? Because if u add this piece of code at the bottom of the file, it's throwing internal error. After removing <?php, it's working.