### PR TITLE
[Mkdocs] Update Copyright + added Twitter Link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: "mailcow: dockerized documentation"
 site_url: https://mailcow.github.io/mailcow-dockerized-docs/
-copyright: "Copyright &copy; 2021 André Peters"
+copyright: "Copyright &copy; 2022 André Peters & Community"
 repo_name: mailcow/mailcow-dockerized
 repo_url: https://github.com/mailcow/mailcow-dockerized
 edit_uri: ../mailcow-dockerized-docs/edit/master/docs/
@@ -152,6 +152,8 @@ extra:
       link: https://mailcow.email
     - icon: fontawesome/brands/github-alt
       link: https://github.com/mailcow
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/mailcow_email    
 extra_css: [ extra.css ]
 extra_javascript: [ clients.js ]
 plugins:


### PR DESCRIPTION
This PR changes the Copyright Date to 2022, added the Community as Authors and added the new Twitter Link