### PR TITLE
Update timesyncd.conf NTP server option

### DIFF
--- a/docs/prerequisite-system.md
+++ b/docs/prerequisite-system.md
@@ -148,7 +148,7 @@ To enable NTP you need to run the command `timedatectl set-ntp true`. You also n
 ```
 # vim /etc/systemd/timesyncd.conf
 [Time]
-Servers=0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
+NTP=0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
 ```
 
 ## Hetzner Cloud (and probably others)


### PR DESCRIPTION
Changing the current option "Server=" to "NTP="

Source: https://man7.org/linux/man-pages/man5/timesyncd.conf.5.html