### PR TITLE
Disable prefix in Borgmatic retention

### DIFF
--- a/docs/third_party/third_party-borgmatic.de.md
+++ b/docs/third_party/third_party-borgmatic.de.md
@@ -80,6 +80,7 @@ retention:
     keep_daily: 7
     keep_weekly: 4
     keep_monthly: 6
+    prefix: ""
 
 hooks:
     mysql_databases:

--- a/docs/third_party/third_party-borgmatic.en.md
+++ b/docs/third_party/third_party-borgmatic.en.md
@@ -81,6 +81,7 @@ retention:
     keep_daily: 7
     keep_weekly: 4
     keep_monthly: 6
+    prefix: ""
 
 hooks:
     mysql_databases:


### PR DESCRIPTION
By default, Borgmatic uses `{hostname}-` as the prefix, and creates backups with that prefix. In Docker, the hostname of the container will change every time the container is recreated, so under default settings, Borgmatic will noty prune archives that were created in a different container. This change disables the prefix so Borgmatic will prune any archive according to the retention policy.