### PR TITLE
Nextcloud background job execution

### DIFF
--- a/docs/third_party/third_party-nextcloud.de.md
+++ b/docs/third_party/third_party-nextcloud.de.md
@@ -6,6 +6,30 @@ Nextcloud kann mit dem [helper script](https://github.com/mailcow/mailcow-docker
 
 Für den Fall, dass Sie das Passwort (z.B. für admin) vergessen haben und kein neues anfordern können [über den Passwort-Reset-Link auf dem Login-Bildschirm] (https://docs.nextcloud.com/server/20/admin_manual/configuration_user/reset_admin_password.html?highlight=reset), können Sie durch den Aufruf des Helper-Skripts mit `-r` als Parameter ein neues Passwort setzen. Verwenden Sie diese Option nur, wenn Ihre Nextcloud nicht so konfiguriert ist, dass sie mailcow zur Authentifizierung verwendet, wie im nächsten Abschnitt beschrieben.
 
+## Hintergrund-Aufgaben
+
+Zur Verwendung der empfohlenen Einstellung (Cron) zur Verarbeitung der Hintergrund-Aufgaben müssen in der `docker-compose.override.yml` folgende Zeilen
+ hinzugefügt werden:
+
+```
+version: '2.1'
+services:
+  php-fpm-mailcow:
+    labels:
+      ofelia.enabled: "true"
+      ofelia.job-exec.nextcloud-cron.schedule: "@every 5m"
+      ofelia.job-exec.nextcloud-cron.command: "su www-data -s /bin/bash -c \"/usr/local/bin/php -f /web/nextcloud/cron.php\""
+```
+
+Nachdem diese Zeilen hinzugefügt wurden muss `docker-compose up -d` ausgeführt werden um das Docker image bit den entsprechenden Labels zu versehen. Danach muss
+ zudem der docker scheduler neu gestartet werden, um den neuen Job zu registrieren. Dazu wird `docker-compose restart ofelia-mailcow` ausgeführt. Zur
+ Überprüfung, ob die `ofelia` Konfiguration korrekt ist geladen wurde, kann mittels `docker-compose logs ofelia-mailcow` nach einer Zeile mit dem Inhalt
+ `New job registered "nextcloud-cron" - ...` gesucht werden.
+
+Hierdurch wird alle 5 Minuten die Hintergrundverarbeitung gestartet. Da die Ausführung selbst keine Ausgabe liefert, kann die korrekte Funktionsweise in den
+ Grundeinstellungen von Nextcloud überprüft werden. Hier wird automatisch mit der ersten Ausführung die Hintergrund-Aufgaben Verarbeitung auf `(X) Cron` gesetzt
+ und der Zeitstempel `Letzte Aufgabe ausgeführt ` aktualisiert.
+
 ## Konfigurieren Sie Nextcloud, um mailcow für die Authentifizierung zu verwenden
 
 Im Folgenden wird beschrieben, wie die Authentifizierung über mailcow unter Verwendung des OAuth2-Protokolls eingerichtet wird. Wir nehmen nur an, dass Sie Nextcloud bereits unter _cloud.example.com_ eingerichtet haben und dass Ihre mailcow unter _mail.example.com_ läuft. Es spielt keine Rolle, wenn Ihre Nextcloud auf einem anderen Server läuft, Sie können immer noch mailcow für die Authentifizierung verwenden.
@@ -102,4 +126,3 @@ Es kann vorkommen, dass Sie die Nextcloud-Instanz von Ihrem Netzwerk aus nicht e
 
 Nachdem die Änderungen vorgenommen wurden, muss der nginx-Container neu gestartet werden.
 `docker-compose restart nginx-mailcow`
-


### PR DESCRIPTION
adding a new section about how to add background job execution with `ofelia` for Nextcloud

closes: #367