### PR TITLE
Increase ReceiveTimeout value.

### DIFF
--- a/docs/manual-guides/ClamAV/u_e-clamav-additional_dbs.de.md
+++ b/docs/manual-guides/ClamAV/u_e-clamav-additional_dbs.de.md
@@ -11,7 +11,7 @@ Die Standard ClamAV Datenbanken haben keine hohe Trefferquote, können aber durc
 
 1. Kostenfreien Account auf https://www.securiteinfo.com/clients/customers/signup erstellen.
 2. Sie erhalten eine E-Mail um Ihren Account zu aktivieren gefolgt von einer E-Mail mit Ihrem Login Namen.
-3. Loggen Sie sich ein und navigieren Sie zu ihrem Account https://www.securiteinfo.com/clients/customers/account
+3. Loggen Sie sich ein und navigieren Sie zu Ihrem Account https://www.securiteinfo.com/clients/customers/account
 4. Klicken Sie auf den 'Setup' Reiter.
 5. Sie brauchen `your_id` von den Downloadlinks. **Diese sind pro User individuell**.
 7. Fügen Sie diese wie folgt in die `data/conf/clamav/freshclam.conf` ein und ersetzen Sie den `your_id` Teil mit Ihrer ID:
@@ -25,7 +25,9 @@ DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securitein
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfopdf.hdb
 ```
 
-8. Passen Sie `data/conf/clamav/clamd.conf` mit den folgenden Einstellungen an:
+8. Bei den kostenlosen SecuriteInfo Datenbanken ist die Download-Geschwindigkeit auf 300 kB/s begrenzt. Ändern Sie in `data/conf/clamav/freshclam.conf` den Standardwert `ReceiveTimeout 20` auf `ReceiveTimeout 90` (Zeitangabe in Sekunden), da ansonsten einige der Datenbank-Downloads aufgrund ihrer Größe abbrechen können.
+
+9. Passen Sie `data/conf/clamav/clamd.conf` mit den folgenden Einstellungen an:
 ```
 DetectPUA yes
 ExcludePUA PUA.Win.Packer
@@ -41,7 +43,7 @@ MaxHTMLNormalize 50M
 MaxScriptNormalize 50M
 MaxZipTypeRcg 50M
 ```
-9. Starten Sie den ClamAV Container neu:
+10. Starten Sie den ClamAV Container neu:
 ```bash
 docker-compose restart clamd-mailcow
 ```

--- a/docs/manual-guides/ClamAV/u_e-clamav-additional_dbs.en.md
+++ b/docs/manual-guides/ClamAV/u_e-clamav-additional_dbs.en.md
@@ -1,6 +1,6 @@
 ## Additional Databases for ClamAV
 
-Default ClamAV databases has not great detection level, but it could be enhanced with free or paid signature databases.
+Default ClamAV databases do not have great detection levels, but it can be enhanced with free or paid signature databases.
 
 ### List of known free databases | As of April 2022
 
@@ -25,7 +25,9 @@ DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securitein
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfopdf.hdb
 ```
 
-8. Adjust `data/conf/clamav/clamd.conf` to align with next settings:
+8. For free SecuriteInfo databases, download speed is limited to 300 kB/s. In `data/conf/clamav/freshclam.conf`, increase the default `ReceiveTimeout 20` value to `ReceiveTimeout 90` (time in seconds), otherwise some of the database downloads could fail because of their size.
+
+9. Adjust `data/conf/clamav/clamd.conf` to align with next settings:
 ```
 DetectPUA yes
 ExcludePUA PUA.Win.Packer
@@ -41,7 +43,7 @@ MaxHTMLNormalize 50M
 MaxScriptNormalize 50M
 MaxZipTypeRcg 50M
 ```
-9. Restart ClamAV container:
+10. Restart ClamAV container:
 ```bash
 docker-compose restart clamd-mailcow
 ```


### PR DESCRIPTION
Download speed for free SecuriteInfo databases is limited to 300 kB/s, the default timeout of 20 sec is too low for some of the larger databases (like javascript.ndb with 15 MB) so downloads will fail.

Fixed a few language issues as well.