### PR TITLE
Add cert info to third_party nextcloud doc

### DIFF
--- a/docs/third_party/third_party-nextcloud.de.md
+++ b/docs/third_party/third_party-nextcloud.de.md
@@ -6,6 +6,8 @@ Nextcloud kann mit dem [helper script](https://github.com/mailcow/mailcow-docker
 
 Für den Fall, dass Sie das Passwort (z.B. für admin) vergessen haben und kein neues anfordern können [über den Passwort-Reset-Link auf dem Login-Bildschirm] (https://docs.nextcloud.com/server/20/admin_manual/configuration_user/reset_admin_password.html?highlight=reset), können Sie durch den Aufruf des Helper-Skripts mit `-r` als Parameter ein neues Passwort setzen. Verwenden Sie diese Option nur, wenn Ihre Nextcloud nicht so konfiguriert ist, dass Sie mailcow zur Authentifizierung verwendet, wie im nächsten Abschnitt beschrieben.
 
+Damit mailcow ein Zertifikat für die Nextcloud Domain generieren kann, muss die Domain unter welcher die Nextcloud später erreichbar sein soll als ADDITIONAL_SAN in die mailcow.conf hinzufügt werden und `docker-compose up -d` zur Übernahme ausgeführt werden. Für weitere Informationen siehe: [Erweitertes SSL](../post_installation/firststeps-ssl.md).
+
 ## Hintergrund-Aufgaben
 
 Zur Verwendung der empfohlenen Einstellung (Cron) zur Verarbeitung der Hintergrund-Aufgaben müssen in der `docker-compose.override.yml` folgende Zeilen

--- a/docs/third_party/third_party-nextcloud.en.md
+++ b/docs/third_party/third_party-nextcloud.en.md
@@ -7,6 +7,9 @@ Nextcloud can be set up (parameter `-i`) and removed (parameter `-p`) with the [
 
 In case you have forgotten the password (e.g. for admin) and can't request a new one [via the password reset link on the login screen](https://docs.nextcloud.com/server/20/admin_manual/configuration_user/reset_admin_password.html?highlight=reset) calling the helper script with `-r` as parameter allows you to set a new password. Only use this option if your Nextcloud isn't configured to use mailcow for authentication as described in the next section.
 
+In order for mailcow to generate a a certificate for the nextcloud domain you need to add "nextcloud.domain.tld" to ADDITIONAL_SAN in mailcow.conf and run `docker-compose up -d` to apply. For more informaton refer to: [Advanced SSL](https://mailcow.github.io/mailcow-dockerized-docs/post_installation/firststeps-ssl/).
+
+
 ## Background jobs
 
 To use the recommended setting (cron) to execute the background jobs following lines need to be added to the `docker-compose.override.yml`:

--- a/docs/third_party/third_party-nextcloud.en.md
+++ b/docs/third_party/third_party-nextcloud.en.md
@@ -1,4 +1,3 @@
-
 ## Manage Nextcloud using the helper script
 
 Nextcloud can be set up (parameter `-i`) and removed (parameter `-p`) with the [helper script](https://github.com/mailcow/mailcow-dockerized/raw/master/helper-scripts/nextcloud.sh) included with mailcow. In order to install Nextcloud simply navigate to your mailcow-dockerized root folder and run the helper script as follows:
@@ -7,8 +6,7 @@ Nextcloud can be set up (parameter `-i`) and removed (parameter `-p`) with the [
 
 In case you have forgotten the password (e.g. for admin) and can't request a new one [via the password reset link on the login screen](https://docs.nextcloud.com/server/20/admin_manual/configuration_user/reset_admin_password.html?highlight=reset) calling the helper script with `-r` as parameter allows you to set a new password. Only use this option if your Nextcloud isn't configured to use mailcow for authentication as described in the next section.
 
-In order for mailcow to generate a a certificate for the nextcloud domain you need to add "nextcloud.domain.tld" to ADDITIONAL_SAN in mailcow.conf and run `docker-compose up -d` to apply. For more informaton refer to: [Advanced SSL](https://mailcow.github.io/mailcow-dockerized-docs/post_installation/firststeps-ssl/).
-
+In order for mailcow to generate a a certificate for the nextcloud domain you need to add "nextcloud.domain.tld" to ADDITIONAL_SAN in mailcow.conf and run `docker-compose up -d` to apply. For more informaton refer to: [Advanced SSL](../post_installation/firststeps-ssl.md).
 
 ## Background jobs
 


### PR DESCRIPTION
Add instructions around configuring ADDITIONAL_SAN for the Nextcloud domain with a reference to more detailed documentation.