### PR TITLE
Added note to DNS setup configuration

### DIFF
--- a/docs/prerequisite/prerequisite-dns.de.md
+++ b/docs/prerequisite/prerequisite-dns.de.md
@@ -28,6 +28,8 @@ autoconfig IN CNAME mail.example.org. (Ihr ${MAILCOW_HOSTNAME})
 @ IN MX 10 mail.example.org. (Ihr ${MAILCOW_HOSTNAME})
 ```
 
+**Hinweis:** Der `mail` DNS-Eintrag, der die Subdomain an die angegebene IP-Adresse bindet, muss nur für die Domain gesetzt werden, auf der mailcow läuft und die für den Zugriff auf das Webinterface verwendet wird. Für jede andere von mailcow verwaltete Domain leitet der `MX`-Eintrag den Datenverkehr entsprechend weiter.
+
 ## DKIM, SPF und DMARC
 
 Im folgenden Beispiel für eine DNS-Zonendatei wird ein einfacher **SPF** TXT-Eintrag verwendet, um nur DIESEM Server (dem MX) zu erlauben, E-Mails für Ihre Domäne zu senden. Jeder andere Server ist nicht zugelassen, kann es aber tun ("`~all`"). Weitere Informationen finden Sie im [SPF-Projekt](http://www.open-spf.org/).

--- a/docs/prerequisite/prerequisite-dns.en.md
+++ b/docs/prerequisite/prerequisite-dns.en.md
@@ -28,6 +28,8 @@ autoconfig          IN CNAME   mail.example.org. (your ${MAILCOW_HOSTNAME})
 @                   IN MX 10   mail.example.org. (your ${MAILCOW_HOSTNAME})
 ```
 
+**Note:** The `mail` DNS record which binds the subdomain to the given ip address must only be set for the domain on which mailcow is running and that is used to access the web interface. For every other mailcow managed domain, the `MX` record will route the traffic.
+
 ## DKIM, SPF and DMARC
 
 In the example DNS zone file snippet below, a simple **SPF** TXT record is used to only allow THIS server (the MX) to send mail for your domain. Every other server is disallowed but able to ("`~all`"). Please refer to [SPF Project](http://www.open-spf.org/) for further reading.


### PR DESCRIPTION
Hello all,

I have added a small hint to the DNS setup documentation, because the `mail` DNS record which binds the subdomain to the given ip address must only be set for the domain on which mailcow is running and that is used to access the web interface.

If this DNS recotd is created for another domain for which email addresses exist in mailcow, it will only result in a certificate warning by calling the `mail` subdomain.