### PR TITLE
Added section to check rsyslog listens on port 514 udp

### DIFF
--- a/docs/post_installation/firststeps-logging.de.md
+++ b/docs/post_installation/firststeps-logging.de.md
@@ -68,16 +68,27 @@ services:
       options:
         syslog-address: "udp://127.0.0.1:514"
         syslog-facility: "local3"
+```
 
-# Nur für Rsyslog:
-# Um die local3-Eingabe nach /var/log/mailcow.log zu verschieben und die Verarbeitung zu beenden, erstellen Sie eine Datei "/etc/rsyslog.d/docker.conf":
-
-local3.* /var/log/mailcow.logs
-& stop
-
-# Danach rsyslog neu starten.
+##### Nur für rsyslog:
+ 
+Stellen Sie sicher, dass folgende Zeilen in `/etc/rsyslog.conf` nicht auskommentiert sind:
 
 ```
+# provides UDP syslog reception
+module(load="imudp")
+input(type="imudp" port="514")
+```
+
+Um Eingänge von `local3` in `/var/log/mailcow.log` zu leiten und danach die Verarbeitung zu stoppen,
+erstellen Sie die Datei `/etc/rsyslog.d/docker.conf`:
+
+```
+local3.*        /var/log/mailcow.log
+& stop
+```
+
+Starten Sie rsyslog danach neu.
 
 #### Über daemon.json (global)
 

--- a/docs/post_installation/firststeps-logging.en.md
+++ b/docs/post_installation/firststeps-logging.en.md
@@ -68,16 +68,26 @@ services:
       options:
         syslog-address: "udp://127.0.0.1:514"
         syslog-facility: "local3"
+```
 
-# For Rsyslog only:
-# To move local3 input to /var/log/mailcow.log and stop processing, create a file "/etc/rsyslog.d/docker.conf":
-
-local3.*        /var/log/mailcow.logs
-& stop
-
-# Restart rsyslog afterwards.
+##### For Rsyslog only:
+ 
+Make sure the following lines aren't commented out in `/etc/rsyslog.conf`:
 
 ```
+# provides UDP syslog reception
+module(load="imudp")
+input(type="imudp" port="514")
+```
+
+To move `local3` input to `/var/log/mailcow.log` and stop processing, create a file `/etc/rsyslog.d/docker.conf`:
+
+```
+local3.*        /var/log/mailcow.log
+& stop
+```
+
+Restart rsyslog afterwards.
 
 #### via daemon.json (globally)
 


### PR DESCRIPTION
As rsyslog doesn't listen on 514 UDP with the default configuration file shipped with Debian 10 and 11, I added a section to enable syslog reception via UDP.