### PR TITLE
Fixed sed regular expression for disabling ipv6

### DIFF
--- a/docs/post_installation/firststeps-disable_ipv6.de.md
+++ b/docs/post_installation/firststeps-disable_ipv6.de.md
@@ -89,7 +89,7 @@ Folgende NGINX, Dovecot und Php-fpm Konfigurationsdateien anpassen
 ```
 sed -i '/::/d' data/conf/nginx/listen_*
 sed -i '/::/d' data/conf/nginx/templates/listen*
+sed -i '/::/d' data/conf/nginx/dynmaps.conf
 sed -i 's/,\[::\]//g' data/conf/dovecot/dovecot.conf
-sed -i 's/\[::\]://g' data/conf/nginx/dynmaps.conf
 sed -i 's/\[::\]://g' data/conf/phpfpm/php-fpm.d/pools.conf
 ```

--- a/docs/post_installation/firststeps-disable_ipv6.en.md
+++ b/docs/post_installation/firststeps-disable_ipv6.en.md
@@ -89,8 +89,8 @@ Fix the following NGINX, Dovecot and php-fpm config files
 ```
 sed -i '/::/d' data/conf/nginx/listen_*
 sed -i '/::/d' data/conf/nginx/templates/listen*
+sed -i '/::/d' data/conf/nginx/dynmaps.conf
 sed -i 's/,\[::\]//g' data/conf/dovecot/dovecot.conf
-sed -i 's/\[::\]://g' data/conf/nginx/dynmaps.conf
 sed -i 's/\[::\]://g' data/conf/phpfpm/php-fpm.d/pools.conf
 ```
 


### PR DESCRIPTION
Running the commands as they were before caused a duplicate "listen" entry in the nginx dynmaps configuration file. Like this:

```
server {
  listen 8081;
  listen 8081;
...
```

Causing nginx to reject the configuration and failing to start.