### PR TITLE
Minor fixes in redis and rspamd docs

### DIFF
--- a/docs/manual-guides/Redis/u_e-redis.de.md
+++ b/docs/manual-guides/Redis/u_e-redis.de.md
@@ -18,7 +18,7 @@ Hier sind einige nützliche Befehle für den redis-cli zur Fehlersuche:
 
 ```
 # docker-compose exec redis-mailcow redis-cli
-127.0.0.1:6379> überwachen
+127.0.0.1:6379> monitor
 OK
 1494077286.401963 [0 172.22.1.253:41228] "SMEMBERS" "BAYES_SPAM_keys"
 1494077288.292970 [0 172.22.1.253:41229] "SMEMBERS" "BAYES_SPAM_keys"

--- a/docs/manual-guides/Rspamd/u_e-rspamd.de.md
+++ b/docs/manual-guides/Rspamd/u_e-rspamd.de.md
@@ -98,7 +98,7 @@ Speichern Sie die Datei und starten Sie "rspamd-mailcow" neu: `docker-compose re
 
 ## Spamfilter-Schwellenwerte (global)
 
-Jeder Benutzer kann [seine Spam-Bewertung](../mailcow-UI/u_e-mailcow_ui-spamfilter.md) individuell ändern. Um eine neue **serverweite** Grenze zu definieren, editieren Sie `data/conf/rspamd/local.d/actions.conf`:
+Jeder Benutzer kann [seine Spam-Bewertung](../mailcow-UI/u_e-mailcow_ui-spamfilter.de.md) individuell ändern. Um eine neue **serverweite** Grenze zu definieren, editieren Sie `data/conf/rspamd/local.d/actions.conf`:
 
 ```cpp
 reject = 15;
@@ -175,7 +175,7 @@ redis-cli --scan --pattern RL* | xargs redis-cli unlink
 Starten Sie Rspamd neu:
 
 ```bash
-docker-compose exec redis-mailcow sh
+docker-compose restart rspamd-mailcow
 ```
 
 ## Erneutes Senden von Quarantäne-Benachrichtigungen auslösen

--- a/docs/manual-guides/Rspamd/u_e-rspamd.en.md
+++ b/docs/manual-guides/Rspamd/u_e-rspamd.en.md
@@ -99,7 +99,7 @@ Save the file and restart "rspamd-mailcow": `docker-compose restart rspamd-mailc
 
 ## Spam filter thresholds (global)
 
-Each user is able to change [their spam rating individually](../mailcow-UI/u_e-mailcow_ui-spamfilter.md). To define a new **server-wide** limit, edit `data/conf/rspamd/local.d/actions.conf`:
+Each user is able to change [their spam rating individually](../mailcow-UI/u_e-mailcow_ui-spamfilter.en.md). To define a new **server-wide** limit, edit `data/conf/rspamd/local.d/actions.conf`:
 
 ```cpp
 reject = 15;
@@ -176,7 +176,7 @@ redis-cli --scan --pattern RL* | xargs redis-cli unlink
 Restart Rspamd:
 
 ```bash
-docker-compose exec redis-mailcow sh
+docker-compose restart rspamd-mailcow
 ```
 
 ## Trigger a resend of quarantine notifications


### PR DESCRIPTION
Hi, just found minor bugs in the documentation

- mistranslated redis-cli command `monitor`
- broken links due to language file suffix
- wrong command for rspamd-mailcow container restart