### PR TITLE
Fix paths for Borgmatic crontab file.

### DIFF
--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -111,7 +111,7 @@ Container einbinden. Der Container definiert zu diesem Zweck ein Volume namens `
 Erstellen Sie eine neue Textdatei in `data/conf/borgmatic/etc/crontab.txt` mit folgendem Inhalt:
 
 ```
-14 * * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1
+14 * * * * PATH=$PATH:/usr/local/bin /usr/local/bin/borgmatic --stats -v 0 2>&1
 ```
 
 Diese Datei erwartet eine crontab-Syntax. Das hier gezeigte Beispiel veranlasst das Backup, jede Stunde um 14 Minuten nach

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -112,7 +112,7 @@ container. The container defines a volume called `/mnt/borg-repository` for this
 Create a new text file in `data/conf/borgmatic/etc/crontab.txt` with the following content:
 
 ```
-14 * * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1
+14 * * * * PATH=$PATH:/usr/local/bin /usr/local/bin/borgmatic --stats -v 0 2>&1
 ```
 
 This file expects crontab syntax. The example shown here will trigger the backup to run every hour at 14 minutes past


### PR DESCRIPTION
The `borgmatic` binary was moved inside the Docker container, therefore the crontab has to be changed or backups will fail.

See:
https://github.com/borgmatic-collective/docker-borgmatic/commit/7076b56010a76d14adb926598cedaab2a9b23c3e