### PR TITLE
Email decryption to use correct compression level

### DIFF
--- a/docs/manual-guides/Dovecot/u_e-dovecot-mail-crypt.de.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-mail-crypt.de.md
@@ -9,7 +9,7 @@ Rufen Sie Dovecot auf, indem Sie `docker compose exec dovecot-mailcow /bin/bash`
 # Entschlüsseln Sie /var/vmail
 find /var/vmail/ -type f -regextype egrep -regex '.*S=.*W=.*' | while read -r file; do
 if [[ $(head -c7 "$file") == "CRYPTED" ]]; then
-doveadm fs get compress lz4:0:crypt:private_key_path=/mail_crypt/ecprivkey.pem:public_key_path=/mail_crypt/ecpubkey.pem:posix:prefix=/ \
+doveadm fs get compress lz4:1:crypt:private_key_path=/mail_crypt/ecprivkey.pem:public_key_path=/mail_crypt/ecpubkey.pem:posix:prefix=/ \
   "$file" > "/tmp/$(basename "$file")"
   if [[ -s "/tmp/$(basename "$file")" ]]; then
     chmod 600 "/tmp/$(basename "$file")"

--- a/docs/manual-guides/Dovecot/u_e-dovecot-mail-crypt.en.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-mail-crypt.en.md
@@ -9,7 +9,7 @@ Enter Dovecot by running `docker compose exec dovecot-mailcow /bin/bash` in the 
 # Decrypt /var/vmail
 find /var/vmail/ -type f -regextype egrep -regex '.*S=.*W=.*' | while read -r file; do
 if [[ $(head -c7 "$file") == "CRYPTED" ]]; then
-doveadm fs get compress lz4:0:crypt:private_key_path=/mail_crypt/ecprivkey.pem:public_key_path=/mail_crypt/ecpubkey.pem:posix:prefix=/ \
+doveadm fs get compress lz4:1:crypt:private_key_path=/mail_crypt/ecprivkey.pem:public_key_path=/mail_crypt/ecpubkey.pem:posix:prefix=/ \
   "$file" > "/tmp/$(basename "$file")"
   if [[ -s "/tmp/$(basename "$file")" ]]; then
     chmod 600 "/tmp/$(basename "$file")"


### PR DESCRIPTION
As of this Dovecot [commit](https://github.com/dovecot/core/commit/9b420dde6e3df30fbadd55e4e8524c809437ee03), it doesn't permit compression level of 0. 