### PR TITLE
updated docs for install to 1.6.0 - added composer update stanza

### DIFF
--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -181,6 +181,12 @@ bin/installto.sh /web/rc
 # Geben Sie 'Y' ein und drücken Sie die Eingabetaste, um Ihre Installation von Roundcube zu aktualisieren.
 # Geben Sie 'N' ein, wenn folgender Dialog erscheint: "Do you want me to fix your local configuration".
 
+# Sollte im Output eine Notice kommen "NOTICE: Update dependencies by running php composer.phar update --no-dev"  sollte an kurzerhand composer.phar downloaden und die updates durchführen:
+cd /web/rc
+wget https://getcomposer.org/download/2.4.2/composer.phar
+php composer.phar update --no-dev
+# Auf die Frage "Do you trust "roundcube/plugin-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] " bitte mit y antworten.
+
 # Entfernen Sie übrig gebliebene Dateien
 cd /tmp
 rm -rf roundcube*

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -181,6 +181,13 @@ bin/installto.sh /web/rc
 # Type 'Y' and press enter to upgrade your install of Roundcube
 # Type 'N' to "Do you want me to fix your local configuration" if prompted
 
+# If you see  "NOTICE: Update dependencies by running php composer.phar update --no-dev" just download composer.phar and run it:
+cd /web/rc
+wget https://getcomposer.org/download/2.4.2/composer.phar
+php composer.phar update --no-dev
+# When asked "Do you trust "roundcube/plugin-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] " hit y and continue.
+
+
 # Remove leftover files
 cd /tmp
 rm -rf roundcube*


### PR DESCRIPTION
After updating to Roundcube 1.6.0 i was not able to Send mails anymore, due to a missing PEAR class 
``` 
PHP Fatal error:  Uncaught Error: Call to undefined method Net_SMTP::starttls() in /web/rc/program/lib/Roundcube/rcube_smtp.php 
```
After looking at the output from the installto script i noticed that i had to update the dependencies.

This commit shares that information with other users ;)


Signed-off-by: Sebastian Schubert <basti@2-die-4.tk>