### PR TITLE
Added reverse proxy configuration for portainer

### DIFF
--- a/docs/third_party/portainer/third_party-portainer.de.md
+++ b/docs/third_party/portainer/third_party-portainer.de.md
@@ -60,3 +60,21 @@ docker compose up -d && docker compose restart nginx-mailcow
 
 Nun können Sie einfach zu https://${MAILCOW_HOSTNAME}/portainer/ navigieren, um Ihre Portainer-Container-Überwachungsseite anzuzeigen. Sie werden dann aufgefordert, ein neues Passwort für den **admin** Account anzugeben. Nachdem Sie Ihr Passwort eingegeben haben, können Sie sich mit der Portainer UI verbinden.
 
+---
+
+## Reverse Proxy
+
+Wenn Sie einen Reverse-Proxy verwenden, muss dieser noch konfiguriert werden die Websocket Requests richtig weiterzuleiten.
+
+Dies wird für die Docker Konsole und andere Komponenten benötigt.
+
+Hier ist ein Bespiel für Apache:
+
+```
+<Location /portainer/api/websocket/>
+  RewriteEngine on
+  RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC]
+  RewriteCond %{HTTP:CONNECTION} Upgrade$ [NC]
+  RewriteRule /portainer/api/websocket/(.*) ws://127.0.0.1:8080/portainer/api/websocket/$1 [P]
+</Location>
+```

--- a/docs/third_party/portainer/third_party-portainer.en.md
+++ b/docs/third_party/portainer/third_party-portainer.en.md
@@ -59,3 +59,22 @@ docker compose up -d && docker compose restart nginx-mailcow
 ```
 
 Now you can simply navigate to https://${MAILCOW_HOSTNAME}/portainer/ to view your Portainer container monitoring page. You’ll then be prompted to specify a new password for the **admin** account. After specifying your password, you’ll then be able to connect to the Portainer UI.
+
+---
+
+## Reverse Proxy
+
+If you are using a reverse proxy you will have to configure it to properly forward websocket requests.
+
+This needs to be done for the docker console and other components to work.
+
+Here is an example for Apache:
+
+```
+<Location /portainer/api/websocket/>
+  RewriteEngine on
+  RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC]
+  RewriteCond %{HTTP:CONNECTION} Upgrade$ [NC]
+  RewriteRule /portainer/api/websocket/(.*) ws://127.0.0.1:8080/portainer/api/websocket/$1 [P]
+</Location>
+```


### PR DESCRIPTION
If not configured this will result in the following portainer error:

http error: An error occured during websocket exec operation (err=websocket: the client is not using the websocket protocol: 'upgrade' token not found in 'Connection' header) (code=500)"