### PR TITLE
Improve customized Dockerfile

### DIFF
--- a/docs/manual-guides/Docker/u_e-docker-cust_dockerfiles.de.md
+++ b/docs/manual-guides/Docker/u_e-docker-cust_dockerfiles.de.md
@@ -1,17 +1,25 @@
 Sie müssen die Override-Datei mit den entsprechenden Build-Tags in den mailcow: dockerized Root-Ordner (d.h. `/opt/mailcow-dockerized`) kopieren:
-
 ```
 cp helper-scripts/docker-compose.override.yml.d/BUILD_FLAGS/docker-compose.override.yml docker-compose.override.yml
 ```
 
+
 Nehmen Sie Ihre Änderungen in `data/Dockerfiles/$service` vor und erstellen Sie das Image lokal:
-
 ```
-docker build data/Dockerfiles/service -t mailcow/$service
+docker build data/Dockerfiles/$service -t mailcow/$service:$tag
+```
+(Ohne persönlichen :$tag wird automatisch :latest verwendet.)
+
+
+Nun muss dieser gerade erstellte Container in docker-compose.override.yml aktiviert werden, z.B.:
+```
+$service-mailcow:
+    build: ./data/Dockerfiles/$service
+    image: mailcow/$service:$tag
 ```
 
-Nun werden die geänderten Container automatisch neu erstellt:
 
+Abschliessend müssen die geänderten Container automatisch neu erstellt werden:
 ```
 docker compose up -d
 ```

--- a/docs/manual-guides/Docker/u_e-docker-cust_dockerfiles.en.md
+++ b/docs/manual-guides/Docker/u_e-docker-cust_dockerfiles.en.md
@@ -4,10 +4,19 @@ You need to copy the override file with corresponding build tags to the mailcow:
 cp helper-scripts/docker-compose.override.yml.d/BUILD_FLAGS/docker-compose.override.yml docker-compose.override.yml
 ```
 
-Make your changes in `data/Dockerfiles/$service` and build the image locally:
 
+Customize `data/Dockerfiles/$service` and build the image locally:
 ```
-docker build data/Dockerfiles/service -t mailcow/$service
+docker build data/Dockerfiles/$service -t mailcow/$service:$tag
+```
+(without a personalized :$tag docker will use :latest automatically)
+
+
+Now the created image has to be activated in docker-compose.override.yml, e.g.:
+```
+$service-mailcow:
+    build: ./data/Dockerfiles/$service
+    image: mailcow/$service:$tag
 ```
 
 Now auto-recreate modified containers:


### PR DESCRIPTION
I just tried to enhance the customized Dockerfile with my personal experience after just doing this for a customized watchdog container. Personalized $tag and container activation in docker-compose.override.yml was added. Without that the customized container was not used after docker-compose up -d (at least for me).