### PR TITLE
Add automatic container restart to Traefik example

### DIFF
--- a/docs/post_installation/firststeps-rp.de.md
+++ b/docs/post_installation/firststeps-rp.de.md
@@ -215,11 +215,11 @@ services:
         command: --restart-containers ${COMPOSE_PROJECT_NAME}-postfix-mailcow-1,${COMPOSE_PROJECT_NAME}-nginx-mailcow-1,${COMPOSE_PROJECT_NAME}-dovecot-mailcow-1
         network_mode: none
         volumes:
-          # Bilden Sie das Volume, das Traefiks `acme.json' Datei enthält, ein
+          # Binden Sie das Volume, das Traefiks `acme.json' Datei enthält, ein
           - acme:/traefik:ro
           # SSL-Ordner von mailcow einhängen
           - ./data/assets/ssl/:/output:rw
-          # Binde den Docker socket ein um die Container neu zu starten
+          # Binden Sie den Docker Socket ein, damit traefik-certs-dumper die Container neu starten kann
           - /var/run/docker.sock:/var/run/docker.sock:ro
         restart: always
         environment:

--- a/docs/post_installation/firststeps-rp.de.md
+++ b/docs/post_installation/firststeps-rp.de.md
@@ -212,14 +212,15 @@ services:
 
     certdumper:
         image: humenius/traefik-certs-dumper
-        container_name: traefik_certdumper
+        command: --restart-containers ${COMPOSE_PROJECT_NAME}-postfix-mailcow-1,${COMPOSE_PROJECT_NAME}-nginx-mailcow-1,${COMPOSE_PROJECT_NAME}-dovecot-mailcow-1
         network_mode: none
         volumes:
-          # mounten Sie den Ordner, der Traefiks `acme.json' Datei enthält
-          # in diesem Fall wird Traefik von seinem eigenen docker compose in ../traefik gestartet
-          - ../traefik/data:/traefik:ro
+          # Bilden Sie das Volume, das Traefiks `acme.json' Datei enthält, ein
+          - acme:/traefik:ro
           # SSL-Ordner von mailcow einhängen
           - ./data/assets/ssl/:/output:rw
+          # Binde den Docker socket ein um die Container neu zu starten
+          - /var/run/docker.sock:/var/run/docker.sock:ro
         restart: always
         environment:
           # Ändern Sie dies nur, wenn Sie eine andere Domain für Mailcows Web-Frontend verwenden als in der Standard-Konfiguration
@@ -228,6 +229,14 @@ services:
 networks:
   web:
     external: true
+    # Name des externen Netzwerks
+    name: traefik_web
+
+volumes:
+  acme:
+    external: true
+    # Name des externen Docker Volumes, welches Traefiks `acme.json' Datei enthält
+    name: traefik_acme
 ```
 
 Starten Sie die neuen Container mit `docker compose up -d`.

--- a/docs/post_installation/firststeps-rp.en.md
+++ b/docs/post_installation/firststeps-rp.en.md
@@ -222,8 +222,8 @@ services:
           - acme:/traefik:ro
           # Mount mailcow's SSL folder
           - ./data/assets/ssl/:/output:rw
-	  # Mount docker socket to restart containers
-	  - /var/run/docker.sock:/var/run/docker.sock:ro
+          # Mount docker socket to restart containers
+          - /var/run/docker.sock:/var/run/docker.sock:ro
         restart: always
         environment:
           # only change this, if you're using another domain for mailcow's web frontend compared to the standard config


### PR DESCRIPTION
Also switch to volume as it is more flexible than recursive path and add examples for external name

See: https://github.com/kereis/traefik-certs-dumper#automatic-container-restart