### PR TITLE
checkmk cache

### DIFF
--- a/docs/third_party/checkmk/u_e-checkmk.de.md
+++ b/docs/third_party/checkmk/u_e-checkmk.de.md
@@ -20,6 +20,9 @@ Sofern das mailcow-Installationsverzeichnis nicht `/opt/` ist, ist das in der 2.
 
 Danach für euren mailcow-Host in checmk die Services neu inventarisieren und es sollte ein neuer Check mit Namen `mailcow_update` auswählbar sein.
 
+Dadurch wird das `mailcow_update` jedes Mal ausgeführt, wenn der checkmk agentin überprüft wird. Sie können das Ergebnis zwischenspeichern, indem Sie das Skript in einem Unterordner mit dem Namen der Anzahl von Sekunden ablegen, für die Sie es zwischenspeichern möchten. \
+`/usr/lib/check_mk_agent/local/3600/` speichert die Antwort für 3600 Sekunden (1 Stunde).
+
 ## Screenshots
 
 ### Keine Updates verfügbar

--- a/docs/third_party/checkmk/u_e-checkmk.de.md
+++ b/docs/third_party/checkmk/u_e-checkmk.de.md
@@ -18,9 +18,9 @@ exit
 
 Sofern das mailcow-Installationsverzeichnis nicht `/opt/` ist, ist das in der 2. Zeile anzupassen.
 
-Danach für euren mailcow-Host in checmk die Services neu inventarisieren und es sollte ein neuer Check mit Namen `mailcow_update` auswählbar sein.
+Danach für den mailcow-Host in checkmk die Services neu inventarisieren und es sollte ein neuer Check mit Namen `mailcow_update` auswählbar sein.
 
-Dadurch wird das `mailcow_update` jedes Mal ausgeführt, wenn der checkmk agentin überprüft wird. Sie können das Ergebnis zwischenspeichern, indem Sie das Skript in einem Unterordner mit dem Namen der Anzahl von Sekunden ablegen, für die Sie es zwischenspeichern möchten. \
+Der Check `mailcow_update` wird jedes Mal ausgeführt, wenn der checkmk Agent den mailcow Server überprüft. Sie können das Ergebnis zwischenspeichern, indem Sie das Skript in einem Unterordner mit dem Namen der Anzahl von Sekunden ablegen, für die Sie es zwischenspeichern möchten. \
 `/usr/lib/check_mk_agent/local/3600/` speichert die Antwort für 3600 Sekunden (1 Stunde).
 
 ## Screenshots

--- a/docs/third_party/checkmk/u_e-checkmk.en.md
+++ b/docs/third_party/checkmk/u_e-checkmk.en.md
@@ -20,6 +20,9 @@ If the mailcow installation directory is not `/opt/`, adjust this in the 2nd lin
 
 After that re-inventory the services for your mailcow host in checmk and a new check named `mailcow_update` should be selectable.
 
+This will run the `mailcow_update` everytime checkmk agent is checked, you can cache the result by placing the script in a subfolder named the number of seconds you wish to cache it. \
+`/usr/lib/check_mk_agent/local/3600/` will cache the response for an 3600 seconds (1 hour).
+
 ## Screenshots
 
 ### No updates available


### PR DESCRIPTION
This PR is to add information about using the cache ability in checkmk, this is so the check isn't ran every time the agent is checked. The default check interval is 1 minute for checkmk.

To reduce server load when the check happens, it makes sense to cache the result and only run the actual check every hour or so.