### PR TITLE
Manual config urls should use client vars

### DIFF
--- a/docs/client/client-manual.de.md
+++ b/docs/client/client-manual.de.md
@@ -16,7 +16,8 @@ Bitte verwenden Sie "plain" als Authentifizierungsmechanismus. Entgegen der Anna
 
 SOGos Standard-URLs für Kalender (CalDAV) und Kontakte (CardDAV):
 
-1. **CalDAV** - https://mail.example.com/SOGo/dav/user@example.com/Calendar/personal/
-2. **CardDAV** - https://mail.example.com/SOGo/dav/user@example.com/Contacts/personal/
+1. **CalDAV**  <span class="client_variables_unavailable">https://mail.example.com/SOGo/dav/user@example.com/Calendar/personal/</span><span class="client_variables_available">https://<span class="client_var_host"></span>/SOGo/dav/<span class="client_var_email"></span>/Calendar/personal/</span>
 
-Einige Anwendungen verlangen möglicherweise die Verwendung von https://mail.example.com/SOGo/dav/ _oder_ den vollständigen Pfad zu Ihrem Kalender, der in SOGo gefunden und kopiert werden kann.
+2. **CardDAV**  <span class="client_variables_unavailable">https://mail.example.com/SOGo/dav/user@example.com/Contacts/personal/</span><span class="client_variables_available">https://<span class="client_var_host"></span>/SOGo/dav/<span class="client_var_email"></span>/Contacts/personal/</span>
+
+Einige Anwendungen verlangen möglicherweise die Verwendung von <span class="client_variables_unavailable">https://mail.example.com/SOGo/dav/</span><span class="client_variables_available">https://<span class="client_var_host"></span>/SOGo/dav/</span> _oder_ den vollständigen Pfad zu Ihrem Kalender, der in SOGo gefunden und kopiert werden kann.

--- a/docs/client/client-manual.en.md
+++ b/docs/client/client-manual.en.md
@@ -17,7 +17,8 @@ Please use the "plain" password setting as the authentication mechanism. Contrar
 
 SOGos default calendar (CalDAV) and contacts (CardDAV) URLs:
 
-1. **CalDAV** - https://mail.example.com/SOGo/dav/user@example.com/Calendar/personal/
-2. **CardDAV** - https://mail.example.com/SOGo/dav/user@example.com/Contacts/personal/
+1. **CalDAV**  <span class="client_variables_unavailable">https://mail.example.com/SOGo/dav/user@example.com/Calendar/personal/</span><span class="client_variables_available">https://<span class="client_var_host"></span>/SOGo/dav/<span class="client_var_email"></span>/Calendar/personal/</span>
 
-Some applications may require you to use https://mail.example.com/SOGo/dav/ _or_ the full path to your calendar, which can be found and copied from within SOGo.
+2. **CardDAV**  <span class="client_variables_unavailable">https://mail.example.com/SOGo/dav/user@example.com/Contacts/personal/</span><span class="client_variables_available">https://<span class="client_var_host"></span>/SOGo/dav/<span class="client_var_email"></span>/Contacts/personal/</span>
+
+Some applications may require you to use <span class="client_variables_unavailable">https://mail.example.com/SOGo/dav/</span><span class="client_variables_available">https://<span class="client_var_host"></span>/SOGo/dav/</span> _or_ the full path to your calendar, which can be found and copied from within SOGo.


### PR DESCRIPTION
In the client-manual config page the example urls use placeholder values like username@mail.example instead of the values specific to the installation.
I often have to setup manual clients and have to manually replace these values instead of just copying the manual links.
This pr fixes that and uses the username and host addres instead of the example values if available.