### PR TITLE
Add a reminder for SNAT_TO_SOURCE variable after migration

### DIFF
--- a/docs/i_u_m/i_u_m_migration.de.md
+++ b/docs/i_u_m/i_u_m_migration.de.md
@@ -44,4 +44,4 @@ docker compose pull
 docker compose up -d
 ```
 
-**9\.** Zum Schluss ändern Sie Ihre DNS-Einstellungen so, dass sie auf den Zielserver zeigen.
+**9\.** Zum Schluss ändern Sie Ihre DNS-Einstellungen so, dass sie auf den Zielserver zeigen. Prüfen und ändern Sie gegebenenfalls die `SNAT_TO_SOURCE` Variable in der `mailcow.conf` im mailcow-dockerized Ordner, da andernfalls SOGo nicht richtig funktioniert, wenn die ausgehende IP eine andere ist.

--- a/docs/i_u_m/i_u_m_migration.en.md
+++ b/docs/i_u_m/i_u_m_migration.en.md
@@ -44,4 +44,4 @@ docker compose pull
 docker compose up -d
 ```
 
-**9\.** Finally, change your DNS settings to point to the target server.
+**9\.** Finally, change your DNS settings to point to the target server. Also check the `SNAT_TO_SOURCE` variable in your `mailcow.conf` file if you have changed your public IP address, otherwise SOGo may not work.


### PR DESCRIPTION
I have moved our mailcow server from one server to another by following this tutorial, but [mailcow/mailcow-dockerized#4627](https://github.com/mailcow/mailcow-dockerized/issues/4627) has occured, and the problem was the misconfiguration for this variable, I've spent around half an hour on investigation. A reminder has added for this situation in order to prevent some tears :)

After the migration, this variable was pointing the old IPv4 address of the server, thus SOGo could not make IMAP connections; after changing it to the new one the issue was fixed.