### PR TITLE
Update the Dovecot Expunge instructions

### DIFF
--- a/docs/manual-guides/Dovecot/u_e-dovecot-expunge.de.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-expunge.de.md
@@ -111,24 +111,17 @@ version: '2.1'
 
 services:
   
-  ofelia:
-    image: mcuadros/ofelia:latest
-    restart: always
-    command: daemon --docker
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro   
-    network_mode: none
-
   dovecot-mailcow:
     labels:
-      - "ofelia.enabled=true"
-      - "ofelia.job-exec.dovecot-expunge-trash.schedule=0 4 * * *"
-      - "ofelia.job-exec.dovecot-expunge-trash.command=doveadm expunge -A mailbox 'Junk' savedbefore 2w"
-      - "ofelia.job-exec.dovecot-expunge-trash.tty=false"
+      ofelia.enabled: "true"
+      ofelia.job-exec.dovecot-expunge-trash.schedule: "0 0 4 * * *"
+      ofelia.job-exec.dovecot-expunge-trash.command: "doveadm expunge -A mailbox 'Junk' savedbefore 2w"
+      ofelia.job-exec.dovecot-expunge-trash.tty: "false"
 
 ```
 
-Der Job-Controller braucht nur Zugriff auf den Docker Control Socket, um das Verhalten von "exec" zu emulieren. Dann fügen wir unserem Dovecot-Container ein paar Labels hinzu, um den Job-Scheduler zu aktivieren und ihm in einem Cron-kompatiblen Scheduling-Format mitzuteilen, wann er laufen soll. Wenn Sie Probleme mit dem Scheduling-String haben, können Sie [crontab guru](https://crontab.guru/) verwenden. 
+Wir fügen unserem Dovecot-Container ein paar Labels hinzu, um den Job-Scheduler zu aktivieren und ihm in einem Cron-kompatiblen Scheduling-Format mitzuteilen, wann er laufen soll. Hinweis: Ofelia verwendet das [Scheduling-Format](https://pkg.go.dev/github.com/robfig/cron?utm_source=godoc) der Cron-Implementierung von Go, die mit einem Eintrag für Sekunden statt für Minuten beginnt.
+
 Diese docker-compose.override.yml löscht jeden Tag um 4 Uhr morgens alle Mails, die älter als 2 Wochen sind, aus dem Ordner "Junk". Um zu sehen, ob alles richtig gelaufen ist, können Sie nicht nur in Ihrer Mailbox nachsehen, sondern auch im Docker-Log von Ofelia, ob es etwa so aussieht:
 
 ```

--- a/docs/manual-guides/Dovecot/u_e-dovecot-expunge.en.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-expunge.en.md
@@ -109,24 +109,16 @@ version: '2.1'
 
 services:
   
-  ofelia:
-    image: mcuadros/ofelia:latest
-    restart: always
-    command: daemon --docker
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro   
-    network_mode: none
-
   dovecot-mailcow:
     labels:
-      - "ofelia.enabled=true"
-      - "ofelia.job-exec.dovecot-expunge-trash.schedule=0 4 * * *"
-      - "ofelia.job-exec.dovecot-expunge-trash.command=doveadm expunge -A mailbox 'Junk' savedbefore 2w"
-      - "ofelia.job-exec.dovecot-expunge-trash.tty=false"
-
+      ofelia.enabled: "true"
+      ofelia.job-exec.dovecot-expunge-trash.schedule: "0 0 4 * * *"
+      ofelia.job-exec.dovecot-expunge-trash.command: "doveadm expunge -A mailbox 'Junk' savedbefore 2w"
+      ofelia.job-exec.dovecot-expunge-trash.tty: "false"
 ```
 
-The job controller just need access to the docker control socket to be able to emulate the behavior of "exec". Then we add a few label to our dovecot-container to activate the job scheduler and tell him in a cron compatible scheduling format when to run. If you struggle with that schedule string you can use [crontab guru](https://crontab.guru/). 
+We add a few label to our dovecot-container to activate the job scheduler and tell him in a cron compatible scheduling format when to run. Note: Ofelia uses the [scheduling format](https://pkg.go.dev/github.com/robfig/cron?utm_source=godoc) of the Go cron implementation which starts with a field for seconds instead of minutes.
+
 This docker-compose.override.yml deletes all mails older then 2 weeks from the "Junk" folder every day at 4 am. To see if things ran proper, you can not only see in your mailbox but also check Ofelia's docker log if it looks something like this:
 
 ```


### PR DESCRIPTION
This makes the following changes:
- remove the need for an additional Ofelia container in favor of the already running ofelia-mailcow container
- list Ofelia labels as more readable dictionary (like in mailcow's docker-compose.yml)
- fix the scheduling format by adding a field for seconds and a link to the Go cron documentation