### PR TITLE
Correction in traefik.docker.network example

### DIFF
--- a/docs/post_installation/firststeps-rp.de.md
+++ b/docs/post_installation/firststeps-rp.de.md
@@ -232,7 +232,7 @@ services:
         # Websecure ist Port 443, siehe die Datei traefik.toml wie oben.
         - traefik.http.routers.moo.entrypoints=websecure
         # Stellen Sie sicher, dass traefik das Web-Netzwerk verwendet, nicht das mailcowdockerized_mailcow-network
-        - traefik.docker.network=web
+        - traefik.docker.network=traefik_web
 
     certdumper:
         image: humenius/traefik-certs-dumper

--- a/docs/post_installation/firststeps-rp.en.md
+++ b/docs/post_installation/firststeps-rp.en.md
@@ -234,7 +234,7 @@ services:
         #   websecure being port 443, check the traefik.toml file liked above.
         - traefik.http.routers.moo.entrypoints=websecure
         # Make sure traefik uses the web network, not the mailcowdockerized_mailcow-network
-        - traefik.docker.network=web
+        - traefik.docker.network=traefik_web
 
     certdumper:
         image: humenius/traefik-certs-dumper


### PR DESCRIPTION
traefik.docker.network expects a network name the container is connected to. This change suggests using the actual external network name instead of the alias in the networks: section, so as to avoid 502 gateway errors.
Also mentioned here in [traefik docs](https://doc.traefik.io/traefik/routing/providers/docker/#traefikdockernetwork).