### PR TITLE
Update client-thunderbird.en.md

### DIFF
--- a/docs/client/client-thunderbird.de.md
+++ b/docs/client/client-thunderbird.de.md
@@ -1,15 +1,15 @@
 <ol>
 <li>
-  Starten Sie Thunderbird.
+  Öffnen Sie Thunderbird.
 </li>
 <li>
-  Wenn Sie Thunderbird zum ersten Mal starten, werden Sie gefragt, ob Sie eine neue E-Mail-Adresse haben möchten. Klicken Sie auf <i>Überspringen und eine bereits vorhandene E-Mail verwenden</i> und fahren Sie mit Schritt 4 fort.
+  Wenn Sie Thunderbird zum ersten Mal öffnen, werden Sie gefragt, ob Sie eine neue E-Mail-Adresse einrichten möchten. Klicken Sie auf <i>Überspringen und eine bereits vorhandene E-Mail-Adresse verwenden</i> und gehen Sie zum Schritt 4.
 </li>
 <li>
-  Gehen Sie zum <i>Datei</i> Menü und wählen Sie <i>Neu</i>, <i>Bestehendes Mail-Konto...</i>.
+  Klicken Sie auf das Menü <i>Datei</i> und wählen Sie <i>Neu</i>, <i>Bestehendes Mail-Konto...</i>.
 </li>
 <li>
-  Geben Sie Ihren Namen<span class="client_variables_available"> (<code><span class="client_var_name"></span></code>)</span>, Ihre E-Mail-Adresse<span class="client_variables_available"> (<code><span class="client_var_email"></span></code>)</span> und Ihr Passwort ein. Stellen Sie sicher, dass <i>Passwort merken</i> aktiviert ist und klicken Sie auf <i>Weiter</i>.
+  Geben Sie Ihren Namen<span class="client_variables_available"> (<code><span class="client_var_name"></span></code>)</span>, Ihre E-Mail-Adresse<span class="client_variables_available"> (<code><span class="client_var_email"></span></code>)</span> und Ihr Passwort ein. Stellen Sie sicher, dass die Option <i>Passwort merken</i> aktiviert ist und klicken Sie auf <i>Weiter</i>.
 </li>
 <li>
   Sobald die Konfiguration automatisch erkannt wurde, stellen Sie sicher, dass <i>IMAP</i> ausgewählt ist und klicken Sie auf <i>Fertig</i>.
@@ -21,6 +21,9 @@
   Um Ihre Kalender vom Server zu verwenden, klicken Sie auf den Pfeil neben "Kalender" und dann auf die Schaltfläche <i>Verbinden</i> für jeden Kalender, den Sie verwenden möchten.
 </li>
 <li>
-  Klicken Sie auf <i>Beenden</i>, um das Fenster Account Setup zu schließen.
+  (Optional) Wenn Sie alle Unterordner synchronisieren möchten, gehen Sie zum Menü <i>Kontoeinstellungen</i> und wählen Sie <i>Server-Einstellungen</i>. Klicken Sie im Tab <i>Server-Einstellungen</i> auf die Schaltfläche <i>Erweitert</i>. In dem Fenster <i>Erweiterte Kontoeinstellungen</i> deaktivieren Sie das Kontrollkästchen "Nur abonnierte Ordner anzeigen". Klicken Sie auf <i>OK</i>, um die Änderungen zu speichern.
+</li>
+<li>
+  Klicken Sie auf <i>Beenden</i>, um das Fenster "Konto-Einrichtung" zu schließen.
 </li>
 </ol>

--- a/docs/client/client-thunderbird.en.md
+++ b/docs/client/client-thunderbird.en.md
@@ -21,6 +21,9 @@
   To use your calendars from the server, click on the arrow next to "Calendars" and click the <i>Connect</i> button on each calendar you would like to use.
 </li>
 <li>
-  Click <i>Finish to close the Account Setup window.
+  (Optional) If you want Thunderbird to sync all subfolders, go to the <i>Account Settings</i> menu and select <i>Server Settings</i>. In the <i>Server Settings</i> tab, click on the <i>Advanced</i> button. In the <i>Advanced Account Settings</i> window, uncheck the "Show only subscribed folders" checkbox. Click <i>OK</i> to save the changes.
 </li>
-</ol>
+<li>
+  Click <i>Finish</i> to close the Account Setup window.
+</li>
+</ol> 


### PR DESCRIPTION
adding a optional step to sync all folders, instead of only the subscribed ones. This should be especially useful if the "Set handling for tagged mail:" is set to "in subfolder"