### PR TITLE
Update roundcube install instructions

### DIFF
--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -15,7 +15,7 @@ Das roundcube-plugin-installer composer Plugin hat eine [Design-Schwäche](https
 die dazu führen kann, dass composer bei Operationen fehlschlägt, im Rahmen derer Pakete aktualisiert oder deinstalliert
 werden.
 
-Die Fehlermeldung in diesem Falle besagt, dass eine `require`-Anweisung in `autoload_real/php` fehlgeschlagen ist, weil
+Die Fehlermeldung in diesem Falle besagt, dass eine `require`-Anweisung in `autoload_real.php` fehlgeschlagen ist, weil
 eine Datei nicht gefunden werden konnte. Beispiel:
 
 ```
@@ -235,7 +235,7 @@ services:
 Das Ändern des mailcow Passworts aus der Roundcube-Benutzeroberfläche wird durch das password-Plugin ermöglicht. Wir
 konfigurieren dieses zur Verwendung der mailcow-API zur Passwort-Aktualisierung, was es zunächst erfordert, die API zu
 aktivieren und den API-Schlüssel zu ermitteln (Lese-/Schreib-Zugriff notwendig). Die API kann in der
-mailcow-Administrationsoberfläche aktiviert werden, so Sie auch den API-Schlüssel finden.
+mailcow-Administrationsoberfläche aktiviert werden, wo Sie auch den API-Schlüssel finden.
 
 Öffnen Sie `data/web/rc/config/config.inc.php` und aktivieren Sie das Passwort-Plugin, indem Sie es dem
 `$config['plugins']`-Array hinzufügen, zum Beispiel:
@@ -251,7 +251,7 @@ $config['plugins'] = array(
 );
 ```
 
-Konfigurieren Sie das password-Plugin (stellen Sie sicher, __**API_KEY**__ auf Ihren mailcow Lese-/Schreib-API-Schlüssel
+Konfigurieren Sie das password-Plugin (stellen Sie sicher, __\*\*API_KEY\*\*__ auf Ihren mailcow Lese-/Schreib-API-Schlüssel
 anzupassen):
 
 ```bash
@@ -598,7 +598,7 @@ EOCONFIG
 ### Umstellung des RCMCardDAV-Plugins auf die Installation mittels composer
 
 Dieser Schritt ist optional, aber er gleicht Ihre Installation an die aktuelle Fassung der Anweisungen an und ermöglicht
-die Aktualisierung von RCMCardDAV mittels composer. Dies wird einfach dadurch erreicht, indem das carddav-Plugin aus dem
+die Aktualisierung von RCMCardDAV mittels composer. Dies wird einfach dadurch erreicht, dass das carddav-Plugin aus dem
 Installationsverzeichnis gelöscht und entsprechend der [Anweisungen oben](#CardDAV-Adressbücher-in-Roundcube-einbinden)
 installiert wird, einschließlich der Erstellung einer neuen RCMCardDAV v5-Konfiguration. Falls Sie das RCMCardDAV
 angepasst haben, sollten Sie dieses sichern, bevor Sie das Plugin löschen, und Ihre Anpassungen später in die neue

--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -1,206 +1,375 @@
 ## Installation von Roundcube
 
-Laden Sie Roundcube 1.6.x in das Web htdocs Verzeichnis herunter und entpacken Sie es (hier `rc/`):
-```bash
-# Prüfen Sie, ob eine neuere Version vorliegt!
-cd data/web
-wget -O - https://github.com/roundcube/roundcubemail/releases/download/1.6.1/roundcubemail-1.6.1-complete.tar.gz | tar xfvz -
+Sofern nicht abweichend angegeben wird für alle aufgeführten Kommandos angenommen, dass diese im mailcow
+Installationsverzeichnis ausgeführt werden, d. h. dem Verzeichnis, welches `mailcow.conf` usw. enthält. Bitte führen Sie
+die Kommandos nicht blind aus, sondern verstehen Sie was diese bewirken. Keines der Kommandos sollte einen Fehler
+ausgeben; sollten Sie dennoch auf einen Fehler stoßen, beheben Sie diesen sofern notwendig bevor Sie mit den
+nachfolgenden Kommandos fortfahren.
 
-# Ändern Sie den Ordnernamen
-mv roundcubemail-1.6.1 rc
+### Hinweise zur Verwendung von composer
 
-# Berechtigungen ändern
-chown -R root: rc/
+Diese Anweisungen verwenden das Programm composer zur Aktualisierung der Abhängigkeiten von Roundcube und um
+Roundcube-Plugins zu installieren bzw. zu aktualisieren.
+
+Das roundcube-plugin-installer composer Plugin hat eine [Design-Schwäche](https://github.com/roundcube/plugin-installer/issues/38),
+die dazu führen kann, dass composer bei Operationen fehlschlägt, im Rahmen derer Pakete aktualisiert oder deinstalliert
+werden.
+
+Die Fehlermeldung in diesem Falle besagt, dass eine `require`-Anweisung in `autoload_real/php` fehlgeschlagen ist, weil
+eine Datei nicht gefunden werden konnte. Beispiel:
+
+```
+In autoload_real.php line 43:
+  require(/web/rc/vendor/composer/../guzzlehttp/promises/src/functions_include.php): Failed to open stream: No such file or directory
 ```
 
-Wenn Sie eine Rechtschreibprüfung benötigen, erstellen Sie eine Datei `data/hooks/phpfpm/aspell.sh` mit folgendem Inhalt und geben Sie dann `chmod +x data/hooks/phpfpm/aspell.sh` ein. Dadurch wird eine lokale Rechtschreibprüfung installiert. Beachten Sie, dass die meisten modernen Webbrowser eine eingebaute Rechtschreibprüfung haben, so dass Sie diese vielleicht nicht benötigen.
+Leider treten diese Fehler relativ häufig auf, sie lassen sich jedoch leicht beheben indem der Autoloader aktualisiert
+wird und das fehlgeschlagene Kommando im Anschluss erneut ausgeführt wird:
+
+```bash
+docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer dump-autoload -o
+# Nun das fehlgeschlagene Kommando erneut ausführen
+```
+
+### Vorbereitung
+
+Zunächst laden wir `mailcow.conf` um Zugriff auf die mailcow-Einstellungen innerhalb der nachfolgenden Kommandos zu
+erhalten.
+
+```bash
+source mailcow.conf
+```
+
+Laden Sie Roundcube 1.6.x (prüfen Sie das aktuellste Release und passen Sie die URL entsprechend an) in das web
+Verzeichnis herunter und entpacken Sie es (hier `rc/`):
+
+```bash
+mkdir -m 755 data/web/rc
+wget -O - https://github.com/roundcube/roundcubemail/releases/download/1.6.1/roundcubemail-1.6.1-complete.tar.gz | tar -xvz --no-same-owner -C data/web/rc --strip-components=1 -f -
+docker exec -it $(docker ps -f name=php-fpm-mailcow -q) chown www-data:www-data /web/rc/logs /web/rc/temp
+docker exec -it $(docker ps -f name=php-fpm-mailcow -q) chown root:www-data /web/rc/config
+docker exec -it $(docker ps -f name=php-fpm-mailcow -q) chmod 750 /web/rc/logs /web/rc/temp /web/rc/config
+```
+
+### Optional: Rechtschreibprüfung
+Wenn Sie eine Rechtschreibprüfung benötigen, erstellen Sie eine Datei `data/hooks/phpfpm/aspell.sh` mit folgendem Inhalt
+und geben Sie dann `chmod +x data/hooks/phpfpm/aspell.sh` ein. Dadurch wird eine lokale Rechtschreibprüfung installiert.
+Beachten Sie, dass die meisten modernen Webbrowser eine eingebaute Rechtschreibprüfung haben, so dass Sie diese
+vielleicht nicht benötigen.
+
 ```bash
 #!/bin/bash
 apk update
 apk add aspell-de # oder jede andere Sprache
 ```
 
+### Installation des MIME-Typ-Verzeichnisses
+Laden Sie die `mime.types` Datei herunter, da diese nicht im `php-fpm`-Container enthalten ist.
+
+```bash
+wget -O data/web/rc/config/mime.types http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
+```
+
+### Anlegen der Roundcube-Datenbank
+Erstellen Sie eine Datenbank für Roundcube im mailcow mysql Container. Dies erstellt einen neuen `roundcube`
+Datenbank-Benutzer mit einem Zufallspasswort, welches in die Shell ausgegeben wird und in einer Shell-Variable für die
+Verwendung durch die nachfolgenden Kommandos gespeichert wird. Beachten Sie, dass Sie die `DBROUNDCUBE`-Shell-Variable
+manuell auf das ausgegebene Passwort setzen müssen, falls sie den Installationsprozess unterbrechen und später in einer
+neuen Shell fortsetzen sollten.
+
+```bash
+DBROUNDCUBE=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)
+echo Das Datenbank-Password für den Benutzer roundcube lautet $DBROUNDCUBE
+docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "CREATE DATABASE roundcubemail CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "CREATE USER 'roundcube'@'%' IDENTIFIED BY '${DBROUNDCUBE}';"
+docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "GRANT ALL PRIVILEGES ON roundcubemail.* TO 'roundcube'@'%';"
+```
+
+### Roundcube-Konfigurationsdatei
+
 Erstellen Sie eine Datei `data/web/rc/config/config.inc.php` mit dem folgenden Inhalt.
-   - **Ändern Sie den Parameter `des_key` auf einen Zufallswert.** Er wird verwendet, um Ihr IMAP-Passwort vorübergehend zu speichern.
-   - Der `db_prefix` ist optional, wird aber empfohlen.
-   - Wenn Sie die Rechtschreibprüfung im obigen Schritt nicht installiert haben, entfernen Sie den Parameter `spellcheck_engine` und ersetzen ihn durch `$config['enable_spellcheck'] = false;`.
-```php
+  - Die `des_key`-Einstellung wird auf einen Zufallswert gesetzt. Sie wird u. a. zur Verschlüsselung vorübergehend
+    gespeicherter IMAP-Passwörter verwendet.
+  - Die Liste der Plugins kann nach Belieben angepasst werden. Die folgende Liste enthält eine Liste von
+    Standard-Plugins, welche ich als allgemein nützlich empfinde und die gut mit mailcow zusammenspielen:
+    - Das archive-Plugin fügt einen Archiv-Button hinzu, der ausgewählte E-Mails in ein konfigurierbares
+      Archiv-Verzeichnis verschiebt.
+    - Das managesieve-Plugin bietet eine benutzerfreundliche Oberfläche zur Verwaltung serverseitiger E-Mail-Filter und
+      Abwesenheits-Benachrichtigungen.
+    - Das acl-Plugin ermöglicht die Verwaltung von Zugriffskontroll-Listen auf IMAP-Verzeichnissen, mit der Möglichkeit
+      IMAP-Verzeichnisse mit anderen Benutzern zu teilen.
+    - Das markasjunk-Plugin fügt Buttons hinzu, um ausgewählte E-Mails als Spam (oder E-Mails im Junk-Verzeichnis nicht
+      als Spam) zu markieren und diese in das Junk-Verzeichnis (oder zurück in den Posteingang) zu verschieben. Die in
+      mailcow enthaltenen Sieve-Filter lösen automatisch die zugehörige Lern-Operation in rspamd aus, so dass keine
+      weitere Konfiguration des Plugins erforderlich ist.
+    - Das zipdownload-Plugin erlaubt es, mehrere E-Mail-Anhänge oder E-Mails als ZIP-Archiv herunterzuladen.
+  - Wenn Sie die Rechtschreibprüfung im obigen Schritt nicht installiert haben, entfernen Sie den Parameter
+    `spellcheck_engine`.
+
+```bash
+cat <<EOCONFIG >data/web/rc/config/config.inc.php
 <?php
-error_reporting(0);
-if (!file_exists('/tmp/mime.types')) {
-file_put_contents("/tmp/mime.types", fopen("http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types", 'r'));
+\$config['db_dsnw'] = 'mysql://roundcube:${DBROUNDCUBE}@mysql/roundcubemail';
+\$config['imap_host'] = 'dovecot:143';
+\$config['smtp_host'] = 'postfix:588';
+\$config['smtp_user'] = '%u';
+\$config['smtp_pass'] = '%p';
+\$config['support_url'] = '';
+\$config['product_name'] = 'Roundcube Webmail';
+\$config['cipher_method'] = 'chacha20-poly1305';
+\$config['des_key'] = '$(LC_ALL=C </dev/urandom tr -dc "A-Za-z0-9 !#$%&()*+,-./:;<=>?@[\\]^_{|}~" 2> /dev/null | head -c 32)';
+\$config['plugins'] = [
+  'archive',
+  'managesieve',
+  'acl',
+  'markasjunk',
+  'zipdownload',
+];
+\$config['spellcheck_engine'] = 'aspell';
+\$config['mime_types'] = '/web/rc/config/mime.types';
+\$config['enable_installer'] = true;
+
+\$config['managesieve_host'] = 'dovecot:4190';
+// Enables separate management interface for vacation responses (out-of-office)
+// 0 - no separate section (default); 1 - add Vacation section; 2 - add Vacation section, but hide Filters section
+\$config['managesieve_vacation'] = 1;
+EOCONFIG
+
+docker exec -it $(docker ps -f name=php-fpm-mailcow -q) chown root:www-data /web/rc/config/config.inc.php
+docker exec -it $(docker ps -f name=php-fpm-mailcow -q) chmod 640 /web/rc/config/config.inc.php
+```
+
+### Initialisierung der Datenbank
+Richten Sie Ihren Browser auf `https://myserver/rc/installer`. Prüfen Sie, dass die Webseite in keinem der Schritte "NOT
+OK"-Testergebnisse zeigt. Einige "NOT AVAILABLE"-Testergebnisse sind bzgl. der verschiedenen Datenbank-Erweiterungen
+erwartet, von denen nur MySQL benötigt wird.
+
+Initialisieren Sie die Datenbank und verlassen Sie das Installationsprogramm. Es ist nicht notwendig, die
+Konfigurationsdatei mit der heruntergeladenen Datei zu aktualisieren, sofern Sie keine Änderungen an den Einstellungen
+innerhalb des Installationsprogramms durchgeführt habe, die Sie übernehmen möchten.
+
+### Webserver-Konfiguration
+
+Das Roundcube-Verzeichnis enthält einige Inhalte, die nicht an Web-Nutzer ausgeliefert werden sollen. Wir erstellen
+daher eine Konfigurations-Ergänzung für nginx, um nur die öffentlichen Teile von Roundcube im Web zu exponieren:
+
+```bash
+cat <<EOCONFIG >data/conf/nginx/site.roundcube.custom
+location /rc/ {
+  alias /web/rc/public_html/;
 }
-$config = array();
-$config['db_dsnw'] = 'mysql://' . getenv('DBUSER') . ':' . getenv('DBPASS') . '@mysql/' . getenv('DBNAME');
-$config['imap_host'] = 'tls://dovecot:143';
-$config['smtp_host'] = 'tls://postfix:587';
-$config['smtp_user'] = '%u';
-$config['smtp_pass'] = '%p';
-$config['support_url'] = '';
-$config['product_name'] = 'Roundcube Webmail';
-$config['des_key'] = 'yourrandomstring_changeme';
-$config['log_dir'] = '/dev/null';
-$config['temp_dir'] = '/tmp';
+EOCONFIG
+```
+
+### Deaktivieren und entfernen des Installationsprogramms
+
+Löschen Sie das Verzeichnis `data/web/rc/installer` nach einer erfolgreichen Installation, und setzen Sie die
+`enable_installer`-Option in `data/web/rc/config/config.inc.php` auf `false`:
+
+```bash
+rm -r data/web/rc/installer
+sed -i -e "s/\(\$config\['enable_installer'\].* = \)true/\1false/" data/web/rc/config/config.inc.php
+```
+
+### Aktualisierung der Roundcube-Abhängigkeiten
+
+Dieser Schritt ist nicht unbedingt notwendig, aber zumindest zum Zeitpunkt der Erstellung dieser Anweisungen enthielten
+die mit Roundcube ausgelieferten Abhängigkeiten Versionen mit Sicherheitslücken, daher könnte es eine gute Idee sein,
+die Abhängigkeiten auf die neusten Versionen zu aktualisieren. Aus demselben Grund sollte composer update hin und wieder
+ausgeführt werden.
+
+```bash
+cp -n data/web/rc/composer.json-dist data/web/rc/composer.json
+docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer update --no-dev -o
+```
+
+Sie können außerdem `composer audit` verwenden, um bekannte Sicherheitslücken in den installierten composer-Paketen
+anzuzeigen.
+
+```bash
+docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer audit
+```
+
+### Ermöglichen der Klartext-Authentifizierung für den php-fpm-Container ohne die Verwendung von TLS
+
+Wir müssen die Verwendung von Klartext-Authentifizierung über nicht verschlüsselte Verbindungen (innerhalb der
+Container-Netzwerks) in Dovecot zulassen, was in der Standard-Installation von mailcow nur für den SOGo-Container
+zum gleichen Zweck möglich ist. Danach starten Sie den Dovecot-Container neu, damit die Änderung wirksam wird.
+
+```bash
+cat  <<EOCONFIG >>data/conf/dovecot/extra.conf
+remote ${IPV4_NETWORK}.0/24 {
+  disable_plaintext_auth = no
+}
+remote ${IPV6_NETWORK} {
+  disable_plaintext_auth = no
+}
+EOCONFIG
+
+docker compose restart dovecot-mailcow
+```
+
+### Ofelia-Job für Roundcube-Aufräumtätigkeiten
+
+Roundcube muss regelmässig die Datenbank von nicht mehr benötigter Information befreien. Wir legen einen Ofelia-Job an,
+der das Roundcube `cleandb.sh`-Skript regelmässig ausführt.
+
+Um dies zu tun, fügen Sie folgendes zu `docker-compose.override.yml` hinzu (falls Sie bereits einige Anpassungen für den
+php-fpm-Container durchgeführt haben, fügen Sie die Label dem bestehenden Abschnitt hinzu):
+
+```yml
+version: '2.1'
+services:
+  php-fpm-mailcow:
+    labels:
+      ofelia.enabled: "true"
+      ofelia.job-exec.roundcube_cleandb.schedule: "@every 168h"
+      ofelia.job-exec.roundcube_cleandb.user: "www-data"
+      ofelia.job-exec.roundcube_cleandb.command: "/bin/bash -c \"[ -f /web/rc/bin/cleandb.sh ] && /web/rc/bin/cleandb.sh\""
+```
+
+## Optionale Zusatz-Funktionalitäten
+
+## Aktivieren der Funktion "Passwort ändern" in Roundcube
+
+Das Ändern des mailcow Passworts aus der Roundcube-Benutzeroberfläche wird durch das password-Plugin ermöglicht. Wir
+konfigurieren dieses zur Verwendung der mailcow-API zur Passwort-Aktualisierung, was es zunächst erfordert, die API zu
+aktivieren und den API-Schlüssel zu ermitteln (Lese-/Schreib-Zugriff notwendig). Die API kann in der
+mailcow-Administrationsoberfläche aktiviert werden, so Sie auch den API-Schlüssel finden.
+
+Öffnen Sie `data/web/rc/config/config.inc.php` und aktivieren Sie das Passwort-Plugin, indem Sie es dem
+`$config['plugins']`-Array hinzufügen, zum Beispiel:
+
+```php
 $config['plugins'] = array(
   'archive',
-  'managesieve'
+  'managesieve',
+  'acl',
+  'markasjunk',
+  'zipdownload',
+  'password',
 );
-$config['spellcheck_engine'] = 'aspell';
-$config['mime_types'] = '/tmp/mime.types';
-$config['imap_conn_options'] = array(
-  'ssl' => array('verify_peer' => false, 'verify_peer_name' => false, 'allow_self_signed' => true)
-);
-$config['enable_installer'] = true;
-$config['smtp_conn_options'] = array(
-  'ssl' => array('verify_peer' => false, 'verify_peer_name' => false, 'allow_self_signed' => true)
-);
-$config['db_prefix'] = 'mailcow_rc1';
 ```
 
-Richten Sie Ihren Browser auf `https://myserver/rc/installer` und folgen Sie den Anweisungen.
-Initialisiere die Datenbank und verlasse das Installationsprogramm.
+Konfigurieren Sie das password-Plugin (stellen Sie sicher, __**API_KEY**__ auf Ihren mailcow Lese-/Schreib-API-Schlüssel
+anzupassen):
 
-**Löschen Sie das Verzeichnis `data/web/rc/installer` nach einer erfolgreichen Installation!**
-
-## Konfigurieren Sie die ManageSieve-Filterung
-
-Öffnen Sie `data/web/rc/config/config.inc.php` und ändern Sie die folgenden Parameter (oder fügen Sie sie am Ende der Datei hinzu):
-```php
-$config['managesieve_host'] = 'tls://dovecot:4190';
-$config['managesieve_conn_options'] = array(
-  'ssl' => array('verify_peer' => false, 'verify_peer_name' => false, 'allow_self_signed' => true)
-);
-// Aktiviert separate Verwaltungsschnittstelle für Urlaubsantworten (außer Haus)
-// 0 - kein separater Abschnitt (Standard),
-// 1 - Abschnitt "Urlaub" hinzufügen,
-// 2 - Abschnitt "Urlaub" hinzufügen, aber Abschnitt "Filter" ausblenden
-$config['managesieve_vacation'] = 1;
-```
-
-## Aktivieren Sie die Funktion "Passwort ändern" in Roundcube
-
-Öffnen Sie `data/web/rc/config/config.inc.php` und aktivieren Sie das Passwort-Plugin:
-
-```php
-[...]
-$config['plugins'] = array(
-    'archive',
-    'password',
-);
-[...]
-```
-
-Öffnen Sie `data/web/rc/plugins/password/password.php`, suchen Sie nach `case 'ssha':` und fügen Sie oben hinzu:
-
-```php
-        case 'ssha256':
-            $salt = rcube_utils::random_bytes(8);
-            $crypted = base64_encode( hash('sha256', $password . $salt, TRUE ) . $salt );
-            $prefix  = '{SSHA256}';
-            break;
-```
-
-Öffnen Sie `data/web/rc/plugins/password/config.inc.php` und ändern Sie die folgenden Parameter (oder fügen Sie sie am Ende der Datei hinzu):
-
-```php
-$config['password_driver'] = 'sql';
-$config['password_algorithm'] = 'ssha256';
-$config['password_algorithm_prefix'] = '{SSHA256}';
-$config['password_query'] = "UPDATE mailbox SET password = %P WHERE username = %u";
-```
-
-## CardDAV Adressbücher in Roundcube einbinden
-
-Laden Sie die neueste Version von [RCMCardDAV](https://github.com/mstilkerich/rcmcarddav) in das Roundcube Plugin Verzeichnis und entpacken Sie es (hier `rc/plugins`):
 ```bash
-cd data/web/rc/plugins
-wget -O - https://github.com/mstilkerich/rcmcarddav/releases/download/v4.4.1/carddav-v4.4.1-roundcube16.tar.gz | tar xfvz -
-chown -R root: carddav/
+cat <<EOCONFIG >data/web/rc/plugins/password/config.inc.php
+<?php
+\$config['password_driver'] = 'mailcow';
+\$config['password_confirm_current'] = true;
+\$config['password_mailcow_api_host'] = 'http://nginx';
+\$config['password_mailcow_api_token'] = '**API_KEY**';
+EOCONFIG
 ```
-  
-Kopieren Sie die Datei `config.inc.php.dist` nach `config.inc.php` (hier in `rc/plugins/carddav`) und fügen Sie die folgende Voreinstellung an das Ende der Datei an - vergessen Sie nicht, `mx.example.org` durch Ihren eigenen Hostnamen zu ersetzen:
-```php
-$prefs['SOGo'] = array(
-    'name'         =>  'SOGo',
-    'username'     =>  '%u',
-    'password'     =>  '%p',
-    'url'          =>  'https://mx.example.org/SOGo/dav/%u/',
-    'carddav_name_only' => true,
+
+Hinweis: Sollten Sie die mailcow nginx-Konfiguration so angepasst haben, dass http-Anfragen auf https umgeleitet werden
+(wie z. B. [hier](https://docs.mailcow.email/manual-guides/u_e-80_to_443/) beschrieben), dann wird die direkte
+Verbindung zum nginx-Container via HTTP nicht funktionieren, da nginx kein im Zertifikat enthaltener Hostname ist. In
+solchen Fällen setzen Sie `password_mailcow_api_host` stattdessen auf die öffentliche URI:
+
+```bash
+cat <<EOCONFIG >data/web/rc/plugins/password/config.inc.php
+<?php
+\$config['password_driver'] = 'mailcow';
+\$config['password_confirm_current'] = true;
+\$config['password_mailcow_api_host'] = 'https://${MAILCOW_HOSTNAME}';
+\$config['password_mailcow_api_token'] = '**API_KEY**';
+EOCONFIG
+```
+
+## CardDAV-Adressbücher in Roundcube einbinden
+
+Installieren Sie die neuste v5-Version (die untenstehende Konfiguration ist kompatibel zu v5-Releases) mit composer.
+Antworten Sie `Y`, wenn Sie gefragt werden, ob Sie das Plugin aktivieren möchten.
+
+```bash
+docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer require --update-no-dev -o "roundcube/carddav:~5"
+```
+
+Editieren Sie die Datei `data/web/rc/plugins/carddav/config.inc.php` und fügen Sie folgenden Inhalt hinzu:
+
+```bash
+cat <<EOCONFIG >data/web/rc/plugins/carddav/config.inc.php
+<?php
+\$prefs['_GLOBAL']['pwstore_scheme'] = 'des_key';
+
+\$prefs['SOGo'] = [
+    'accountname'    => 'SOGo',
+    'username'       => '%u',
+    'password'       => '%p',
+    'discovery_url'  => 'http://sogo:20000/SOGo/dav/',
+    'name'           => '%N',
     'use_categories' => true,
-    'active'       =>  true,
-    'readonly'     =>  false,
-    'refresh_time' => '02:00:00',
-    'fixed'        =>  array( 'active', 'name', 'username', 'password', 'refresh_time' ),
-    'hide'        =>  false,
-);
-```
-Bitte beachten Sie, dass dieses Preset nur das Standard-Adressbuch integriert (dasjenige, das den Namen "Persönliches Adressbuch" trägt und nicht gelöscht werden kann). Weitere Adressbücher werden derzeit nicht automatisch erkannt, können aber manuell in den Roundcube-Einstellungen hinzugefügt werden.
-
-Aktivieren Sie das Plugin, indem Sie `carddav` zu `$config['plugins']` in `rc/config/config.inc.php` hinzufügen.
-
-Wenn Sie die Standard-Adressbücher (die in der Roundcube-Datenbank gespeichert sind) entfernen möchten, so dass nur die CardDAV-Adressbücher zugänglich sind, fügen Sie `$config['address_book_type'] = '';` in die Konfigurationsdatei `data/web/rc/config/config.inc.php` ein.
-
----
-
-Optional können Sie Roundcube's Link zu der mailcow Apps Liste hinzufügen.
-Um dies zu tun, öffnen oder erstellen Sie `data/web/inc/vars.local.inc.php` und fügen Sie den folgenden Code-Block hinzu:
-
-*HINWEIS: Vergessen Sie nicht, das `<?php` Trennzeichen in der ersten Zeile einzufügen*
-
-```php
-...
-$MAILCOW_APPS = array(
-  array(
-    'name' => 'SOGo',
-    'link' => '/SOGo/'
-  ),
-  array(
-    'name' => 'Roundcube',
-    'link' => '/rc/'
-   )
-);
-...
+    'fixed'          => ['username', 'password'],
+];
+EOCONFIG
 ```
 
-## Aktualisierung von Roundcube
+RCMCardDAV legt alle Adressbücher des Benutzers beim Login in Roundcube an, einschließlich __abonnierten__ Adressbüchern
+die mit dem Benutzers von anderen Benutzern geteilt werden.
 
-Ein Upgrade von Roundcube ist recht einfach: Gehen Sie auf die [Github releases](https://github.com/roundcube/roundcubemail/releases) Seite für Roundcube und holen Sie sich den Link für die "complete.tar.gz" Datei für die gewünschte Version. Dann folgen Sie den untenstehenden Befehlen und ändern Sie die URL und den Namen des Roundcube-Ordners, falls nötig. 
+Wenn Sie das Standard-Adressbuch (gespeichert in der Roundcube-Datenbank) entfernen möchten, so dass nur
+CardDAV-Adressbücher verwendet werden können, fügen Sie der Konfigurationsdatei `data/web/rc/config/config.inc.php` die
+Option `$config['address_book_type'] = '';` hinzu.
 
+Hinweis: RCMCardDAV verwendet zusätzliche Datenbank-Tabellen. Nach der Installation (oder Aktualisierung) von RCMCardDAV
+ist es notwendig, sich in Roundcube neu anzumelden (melden Sie sich vorher ab, wenn Sie bereits eingeloggt sind), da die
+Erzeugung der Datenbank-Tabellen bzw. Änderungen nur bei der Anmeldung in Roundcube durchgeführt werden.
+
+### Übermittlung der Client-Netzwerkadresse an Dovecot
+
+Normalerweise sieht der IMAP-Server Dovecot die Netzwerkadresse des php-fpm-Containers wenn Roundcube zu diesem
+Verbindungen aufbaut. Durch Verwendung einer IMAP-Erweiterung und dem `roundcube-dovecot_client_ip` Roundcube-Plugin ist
+es möglich, dass Roundcube Dovecot die Client-Netzwerkadresse übermittelt, so dass in den Log-Dateien die
+Client-Netzwerkadresse erscheint. Dies führt dazu, dass Login-Versuche an Roundcube in den Dovecot-Logs genauso wie
+direkte Client-Verbindungen zu Dovecot aufgezeichnet werden, und fehlgeschlagene Login-Versuche an Roundcube
+analog zu fehlgeschlagenen direkten IMAP-Logins durch den netfilter-Container oder andere ggf. verfügbare Mechanismen
+zur Behandlung von Bruteforce-Attacken auf den IMAP-Server aufgegriffen werden und z. B. zu einer Blockierung des
+Clients führen.
+
+Hierzu muss das Roundcube-Plugin installiert werden:
 
 ```bash
-# Starten Sie eine Bash-Sitzung des mailcow PHP-Containers
-docker exec -it mailcowdockerized-php-fpm-mailcow-1 bash
-
-# Installieren Sie die erforderliche Upgrade-Abhängigkeit, dann aktualisieren Sie Roundcube auf die gewünschte Version
-apk add rsync
-cd /tmp
-wget -O - https://github.com/roundcube/roundcubemail/releases/download/1.6.1/roundcubemail-1.6.1-complete.tar.gz | tar xfvz -
-cd roundcubemail-1.6.1
-bin/installto.sh /web/rc
-
-# Geben Sie 'Y' ein und drücken Sie die Eingabetaste, um Ihre Installation von Roundcube zu aktualisieren.
-# Geben Sie 'N' ein, wenn folgender Dialog erscheint: "Do you want me to fix your local configuration".
-
-# Sollte im Output eine Notice kommen "NOTICE: Update dependencies by running php composer.phar update --no-dev"  sollte an kurzerhand composer.phar downloaden und die updates durchführen:
-cd /web/rc
-wget https://getcomposer.org/download/2.4.2/composer.phar
-php composer.phar update --no-dev
-# Auf die Frage "Do you trust "roundcube/plugin-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] " bitte mit y antworten.
-
-# Entfernen Sie übrig gebliebene Dateien
-cd /tmp
-rm -rf roundcube*
-
-# Falls Sie von Version 1.5 auf 1.6 updaten, dann führen Sie folgende Befehle aus, um die Konfigurationsdatei anzupassen:`
-sed -i "s/\$config\['default_host'\].*$/\$config\['imap_host'\]\ =\ 'tls:\/\/dovecot:143'\;/" /web/rc/config/config.inc.php
-sed -i "/\$config\['default_port'\].*$/d" /web/rc/config/config.inc.php
-sed -i "s/\$config\['smtp_server'\].*$/\$config\['smtp_host'\]\ =\ 'tls:\/\/postfix:587'\;/" /web/rc/config/config.inc.php
-sed -i "/\$config\['smtp_port'\].*$/d" /web/rc/config/config.inc.php
-sed -i "s/\$config\['managesieve_host'\].*$/\$config\['managesieve_host'\]\ =\ 'tls:\/\/dovecot:4190'\;/" /web/rc/config/config.inc.php
-sed -i "/\$config\['managesieve_port'\].*$/d" /web/rc/config/config.inc.php
+docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer require --update-no-dev -o "takerukoushirou/roundcube-dovecot_client_ip:~1"
 ```
 
-## Administratoren ohne Passwort in Roundcube einloggen lassen
+Weiterhin müssen wir Dovecot konfigurieren, so dass der php-fpm-Container als Teil eines vertrauenswürdigen Netzwerks
+betrachtet wird und somit die Client-Netzwerkadresse innerhalb einer IMAP-Sitzung überschreiben darf. Beachten Sie, dass
+dies auch die Klartext-Authentifizierung für die aufgeführten Netzwerkbereiche erlaubt, so dass das explizite
+Überschreiben von `disable_plaintext_auth` weiter oben in diesem Fall nicht notwendig ist.
+
+```bash
+cat  <<EOCONFIG >>data/conf/dovecot/extra.conf
+login_trusted_networks = ${IPV4_NETWORK}.0/24 ${IPV6_NETWORK}
+EOCONFIG
+
+docker compose restart dovecot-mailcow
+```
+
+### Roundcube zur mailcow Apps-Liste hinzufügen
+
+Optional können Sie Roundcubes Link zu der mailcow Apps Liste hinzufügen.
+Um dies zu tun, öffnen oder erstellen Sie `data/web/inc/vars.local.inc.php` und stellen Sie sicher, dass es den
+folgenden Konfigurationsblock beinhaltet:
+
+```php
+<?php
+
+$MAILCOW_APPS = [
+    [
+        'name' => 'SOGo',
+        'link' => '/SOGo/'
+    ],
+    [
+        'name' => 'Roundcube',
+        'link' => '/rc/'
+    ]
+];
+```
+
+### Administratoren ohne Passwort in Roundcube einloggen lassen
 
 Installieren Sie zunächst das Plugin [dovecot_impersonate](https://github.com/corbosman/dovecot_impersonate/) und fügen Sie Roundcube als App hinzu (siehe oben).
 
@@ -223,7 +392,6 @@ services:
       - ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE=${ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE:-n}
 ```
 
-
 Bearbeiten Sie `data/web/js/site/mailbox.js` und den folgenden Code nach [`if (ALLOW_ADMIN_EMAIL_LOGIN) { ... }`](https://github.com/mailcow/mailcow-dockerized/blob/2f9da5ae93d93bf62a8c2b7a5a6ae50a41170c48/data/web/js/site/mailbox.js#L485-L487)
 
 ```js
@@ -238,7 +406,7 @@ Bearbeiten Sie `data/web/mailbox.php` und fügen Sie diese Zeile zum Array [`$te
   'allow_admin_email_login_roundcube' => (preg_match("/^(yes|y)+$/i", $_ENV["ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE"])) ? 'true' : 'false',
 ```
 
-Bearbeiten Sie `data/web/templates/mailbox.twig` und fügen Sie diesen Code am Ende des [javascript-Abschnitts](https://github.com/mailcow/mailcow-dockerized/blob/2f9da5ae93d93bf62a8c2b7a5a6ae50a41170c48/data/web/templates/mailbox.twig#L49-L57) ein:
+Bearbeiten Sie `data/web/templates/mailbox.twig` und fügen Sie diesen Code am Ende des [Javascript-Abschnitts](https://github.com/mailcow/mailcow-dockerized/blob/2f9da5ae93d93bf62a8c2b7a5a6ae50a41170c48/data/web/templates/mailbox.twig#L49-L57) ein:
 
 ```js
   var ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE = {{ allow_admin_email_login_roundcube }};
@@ -249,6 +417,7 @@ Kopieren Sie den Inhalt der folgenden Dateien aus diesem [Snippet](https://gitla
 * `data/web/inc/lib/RoundcubeAutoLogin.php`
 * `data/web/rc-auth.php`
 
+## Abschluss der Installation
 Starten Sie schließlich mailcow neu
 
 === "docker compose (Plugin)"
@@ -261,10 +430,233 @@ Starten Sie schließlich mailcow neu
 === "docker-compose (Standalone)"
 
     ``` bash
-    docker-compose down    
+    docker-compose down
     docker-compose up -d
     ```
 
 
+## Aktualisierung von Roundcube
 
+Ein Upgrade von Roundcube ist recht einfach: Gehen Sie auf die
+[GitHub releases](https://github.com/roundcube/roundcubemail/releases) Seite für Roundcube und holen Sie sich den Link
+für die "complete.tar.gz" Datei für die gewünschte Version. Dann folgen Sie den untenstehenden Befehlen und ändern Sie
+die URL und den Namen des Roundcube-Ordners, falls nötig.
 
+```bash
+# Starten Sie eine Bash-Sitzung des mailcow PHP-Containers
+docker exec -it mailcowdockerized-php-fpm-mailcow-1 bash
+
+# Installieren Sie die erforderliche Upgrade-Abhängigkeit, dann aktualisieren Sie Roundcube auf die gewünschte Version
+apk add rsync
+cd /tmp
+wget -O - https://github.com/roundcube/roundcubemail/releases/download/1.6.1/roundcubemail-1.6.1-complete.tar.gz | tar xfvz -
+cd roundcubemail-1.6.1
+bin/installto.sh /web/rc
+
+# Geben Sie 'Y' ein und drücken Sie die Eingabetaste, um Ihre Installation von Roundcube zu aktualisieren.
+# Geben Sie 'N' ein, wenn folgender Dialog erscheint: "Do you want me to fix your local configuration".
+
+# Sollte im Output eine Notice kommen "NOTICE: Update dependencies by running php composer.phar update --no-dev" führen
+Sie composer aus:
+cd /web/rc
+composer update --no-dev -o
+# Auf die Frage "Do you trust "roundcube/plugin-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] " bitte mit y antworten.
+
+# Entfernen Sie übrig gebliebene Dateien
+rm -rf /tmp/roundcube*
+
+# Falls Sie von Version 1.5 auf 1.6 updaten, dann führen Sie folgende Befehle aus, um die Konfigurationsdatei anzupassen:`
+sed -i "s/\$config\['default_host'\].*$/\$config\['imap_host'\]\ =\ 'dovecot:143'\;/" /web/rc/config/config.inc.php
+sed -i "/\$config\['default_port'\].*$/d" /web/rc/config/config.inc.php
+sed -i "s/\$config\['smtp_server'\].*$/\$config\['smtp_host'\]\ =\ 'postfix:588'\;/" /web/rc/config/config.inc.php
+sed -i "/\$config\['smtp_port'\].*$/d" /web/rc/config/config.inc.php
+sed -i "s/\$config\['managesieve_host'\].*$/\$config\['managesieve_host'\]\ =\ 'dovecot:4190'\;/" /web/rc/config/config.inc.php
+sed -i "/\$config\['managesieve_port'\].*$/d" /web/rc/config/config.inc.php
+```
+
+### Aktualisierung von composer-Plugins
+
+Um Roundcube-Plugins und -Abhängigkeiten zu aktualisieren, die mit composer installiert wurden (z. B.
+RCMCardDAV-Plugin), führen Sie einfach composer im Container aus:
+
+```bash
+docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer update --no-dev -o
+```
+
+### Aktualisierung des MIME-Typ-Verzeichnisses
+
+Um das MIME-Typ-Verzeichnis zu aktualisieren, laden Sie dieses erneut mit dem Kommando aus den
+[Installations-Anweisungen](#Installation-des-MIME-Typ-Verzeichnisses) herunter.
+
+## Deinstallation von Roundcube
+
+Für die Deinstallation wird ebenfalls angenommen, dass die Kommandos im mailcow-Installationsverzeichnis ausgeführt
+werden und dass `mailcow.conf` in die Shell geladen wurde, siehe Abschnitt [Vorbereitung](#Vorbereitung) oben.
+
+### Entfernen des Web-Verzeichnisses
+
+Dies entfernt die Roundcube-Installation mit allen Plugins und Abhängigkeiten die Sie ggf. installiert haben,
+einschließlich solcher, die mit composer installiert wurden.
+
+Hinweis: Dies entfernt auch alle angepassten Konfigurationen die Sie ggf. in Roundcube durchgeführt haben. Sollten Sie
+diese erhalten wollen, verschieben Sie das Verzeichnis an einen anderen Ort statt es zu entfernen.
+
+```bash
+rm -r data/web/rc
+```
+
+### Entfernen der Datenbank
+
+Hinweis: Dies löscht alle Daten, die Roundcube abgespeichert hat. Wenn Sie diese erhalten möchten, können Sie
+`mysqldump` ausführen, bevor Sie die Datenbank löschen, oder die Datenbank einfach nicht löschen.
+
+```bash
+docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "DROP USER 'roundcube'@'%';"
+docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "DROP DATABASE roundcubemail;"
+```
+
+### Entfernen der Konfigurationsanpassungen für mailcow
+
+Um die Dateien zu ermitteln, lesen Sie bitte die Installationsanweisungen und machen Sie die Schritte, die Sie dort
+zuvor durchgeführt haben, rückgängig.
+
+## Migration von einer älteren mailcow-Roundcube-Installation
+
+Ältere Versionen dieser Anleitung verwendeten die mailcow-Datenbank auch für Roundcube, mit einem konfigurierten Präfix
+`mailcow_rc1` für alle Roundcube-Tabellen.
+
+Zur Migration wird ebenfalls angenommen, dass alle Kommandos im mailcow-Installationsverzeichnis ausgeführt werden und
+`mailcow.conf` in die Shell geladen wurde, siehe [Vorbereitung](#Vorbereitung) oben. Dies Kommandos der verschiedenen
+Schritte bauen aufeinander auf und müssen innerhalb derselben Shell ausgeführt werden. Insbesondere setzen einige
+Schritte Shell-Variablen (besonders die `DBROUNDCUBE`-Variable mit dem Datenbank-Passwort für den
+roundcube-Datenbankbenutzer), die in späteren Schritten verwendet werden.
+
+### Anlegen eines neuen roundcube-Datenbankbenutzers und der Datenbank
+
+Folgen Sie den [Anweisungen oben](#Anlegen-der-Roundcube-Datenbank) um den roundcube-Datenbankbenutzer und die getrennte
+Datenbank anzulegen.
+
+### Migration der Roundcube-Daten aus der mailcow-Datenbank
+
+Bevor wir mit der Migration starten, deaktivieren wir Roundcube, um weitere Änderungen an dessen Datenbank-Tabellen zu
+vermeiden.
+
+```bash
+cat <<EOCONFIG >data/conf/nginx/site.roundcube.custom
+location ^~ /rc/ {
+  return 503;
+}
+EOCONFIG
+docker compose exec nginx-mailcow nginx -s reload
+```
+
+Nun kopieren wir die Roundcube-Daten in die neue Datenbank. Wir entfernen das Datenbank-Tabellen-Präfix in diesem
+Schritt, welches Sie ggf. anpassen müssen, wenn Sie ein anderes Präfix als `mailcow_rc1` verwendet haben. Es ist auch
+möglich, das Präfix beizubehalten (in diesem Fall behalten Sie auch die zugehörige Roundcube-Einstellung `db_prefix`
+bei).
+
+```bash
+RCTABLES=$(docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -sN mailcow -e "show tables like 'mailcow_rc1%';" | tr '\n\r' ' ')
+docker exec $(docker ps -f name=mysql-mailcow -q) /bin/bash -c "mysqldump -uroot -p${DBROOT} mailcow $RCTABLES | sed 's/mailcow_rc1//' | mysql -uroot -p${DBROOT} roundcubemail"
+```
+
+### Aktualisierung der Roundcube-Konfiguration
+
+Führen Sie folgende Kommandos aus, um die nicht mehr notwendige `db_prefix` Option zu entfernen. Wir aktivieren außerdem
+das Logging in Roundcube, indem wir die Einstellungen `log_dir` und `temp_dir` entfernen, welche Teil der alten
+Anweisungen waren.
+
+```bash
+sed -i "/\$config\['db_prefix'\].*$/d" data/web/rc/config/config.inc.php
+sed -i "/\$config\['log_dir'\].*$/d" data/web/rc/config/config.inc.php
+sed -i "/\$config\['temp_dir'\].*$/d" data/web/rc/config/config.inc.php
+```
+
+Wir müssen die nginx-Konfiguration anpassen, so dass nicht-öffentliche Verzeichnisse von Roundcube nicht exponiert
+werden, insbesondere die Verzeichnisse, welche Log-Dateien und temporäre Dateien enthalten:
+
+```bash
+cat <<EOCONFIG >data/conf/nginx/site.roundcube.custom
+location /rc/ {
+  alias /web/rc/public_html/;
+}
+EOCONFIG
+```
+
+Wir können auch die `cipher_method`-Einstellung auf eine sicherere Einstellung ändern, aber beachten Sie, dass mit der
+alten Methode verschlüsselte Daten danach nicht mehr entschlüsselt werden können. Dies betrifft insbesondere
+CardDAV-Passwörter, sofern Sie RCMCardDAV verwenden und Ihre Nutzer benutzerdefinierte Adressbücher hinzugefügt haben
+(die Admin-Voreinstellungen für die SOGo-Adressbücher werden automatisch beim nächsten Login für den jeweiligen Nutzer
+korrigiert). Wenn Sie die `cipher_method` ändern wollen, führen Sie folgendes Kommando aus:
+
+```bash
+cat <<EOCONFIG >>data/web/rc/config/config.inc.php
+\$config['cipher_method'] = 'chacha20-poly1305';
+EOCONFIG
+```
+
+### Umstellung des RCMCardDAV-Plugins auf die Installation mittels composer
+
+Dieser Schritt ist optional, aber er gleicht Ihre Installation an die aktuelle Fassung der Anweisungen an und ermöglicht
+die Aktualisierung von RCMCardDAV mittels composer. Dies wird einfach dadurch erreicht, indem das carddav-Plugin aus dem
+Installationsverzeichnis gelöscht und entsprechend der [Anweisungen oben](#CardDAV-Adressbücher-in-Roundcube-einbinden)
+installiert wird, einschließlich der Erstellung einer neuen RCMCardDAV v5-Konfiguration. Falls Sie das RCMCardDAV
+angepasst haben, sollten Sie dieses sichern, bevor Sie das Plugin löschen, und Ihre Anpassungen später in die neue
+Konfigurationsdatei übernehmen.
+
+Um das carddav-Plugin zu löschen, führen Sie folgendes Kommando aus, danach befolgen Sie zur Neuinstallation die
+[Anweisungen oben](#CardDAV-Adressbücher-in-Roundcube-einbinden):
+
+```bash
+rm -r data/web/rc/plugins/carddav
+```
+
+### Umschalten von Roundcube auf die neue Datenbank
+
+Zunächst passen wir die Roundcube-Konfiguration an, so dass die neue Datenbank verwendet wird.
+```bash
+sed -i "/\$config\['db_dsnw'\].*$/d" data/web/rc/config/config.inc.php
+cat <<EOCONFIG >>data/web/rc/config/config.inc.php
+\$config['db_dsnw'] = 'mysql://roundcube:${DBROUNDCUBE}@mysql/roundcubemail';
+EOCONFIG
+```
+
+### Roundcube Web-Zugriff reaktivieren
+
+Führen Sie chown und chmod auf den sensitiven Roundcube-Verzeichnissen, welche in [Vorbereitung](#Vorbereitung)
+aufgeführt sind aus, um sicherzustellen, dass der nginx-Webserver nicht auf Dateien zugreifen darf, die er nicht
+ausliefern soll.
+
+Dann reaktivieren Sie den Web-Zugriff für Roundcube, indem Sie die temporäre Roundcube-Konfigurations-Erweiterung für
+nginx durch die [oben](#Webserver-Konfiguration) beschriebene ersetzen, und laden anschließend die nginx-Konfiguration
+neu:
+
+```bash
+docker compose exec nginx-mailcow nginx -s reload
+```
+
+### Andere Anpassungen
+
+Sie müssen auch die Konfiguration des Roundcube password-Plugins entsprechend dieser Anweisungen anpassen, sofern Sie
+diese Funktionalität aktiviert haben, da die alten Anweisungen das Passwort direkt in der mailcow-Datenbank änderten,
+wohingegen diese Fassung der Anweisungen die mailcow-API zur Passwort-Änderung verwendet.
+
+Bezüglich weiterer Anpassungen und Neuerungen (z. B. roundcube-dovecot\_client\_ip Plugin) können Sie die aktuellen
+Anweisungen durchgehen und Ihre Konfiguration entsprechend anpassen bzw. die genannten Installationsschritte für neue
+Funktionalitäten ausführen.
+
+Insbesondere beachten Sie folgende Abschnitte:
+
+  - [Ofelia-Job für Roundcube-Aufräumtätigkeiten](#Ofelia-Job-für-Roundcube-Aufräumtätigkeiten)
+  - [Ermöglichen der Klartext-Authentifizierung für den php-fpm-Container ohne die Verwendung von TLS](#Ermöglichen-der-Klartext-Authentifizierung-für-den-php-fpm-Container-ohne-die-Verwendung-von-TLS)
+  - [Übermittlung der Client-Netzwerkadresse an Dovecot](#Übermittlung-der-Client-Netzwerkadresse-an-Dovecot)
+
+### Entfernen der Roundcube-Tabellen aus der mailcow-Datenbank
+
+Nachdem Sie sichergestellt haben, dass die Migration erfolgreich durchgeführt wurde und Roundcube mit der getrennten
+Datenbank funktioniert, können Sie die Roundcube-Tabellen aus der mailcow-Datenbank mit dem folgenden Kommando
+entfernen:
+
+```bash
+docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -sN mailcow -e "SET SESSION foreign_key_checks = 0; DROP TABLE IF EXISTS $(echo $RCTABLES | sed -e 's/ \+/,/g');"
+```

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -41,7 +41,10 @@ wget -O data/web/rc/config/mime.types http://svn.apache.org/repos/asf/httpd/http
 ```
 
 ### Create roundcube database
-Create a database for roundcube in the mailcow mysql container.
+Create a database for roundcube in the mailcow mysql container. This creates a new `roundcube` database user
+with a random password, which will be echoed to the shell and stored in a shell variable for use by later
+commands. Note that when you interrupt the process and continue in a new shell, you must set the `DBROUNDCUBE`
+shell variable manually to the password output by the following commands.
 
 ```bash
 DBROUNDCUBE=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)
@@ -513,12 +516,18 @@ docker compose exec nginx-mailcow nginx -s reload
 ```
 
 ### Other changes
-You must also adapt the configuration of the roundcube password plugin according to the new instruction, specifically if
+You must also adapt the configuration of the roundcube password plugin according to this instruction, specifically if
 you use the password changing functionality, since the old instruction directly changed the password in the database,
 whereas this version of the instruction uses the mailcow API for the password change.
 
 Regarding other changes and additions (e.g., dovecot\_impersonate plugin), you can go through the current installation
 instructions and adapt your configuration accordingly or perform the listed installation steps for new additions.
+
+If you adapt the roundcube configuration according to the one now used in this instruction, mind not to change the
+`db_prefix`, `cipher_method` and `des_key` options unless you know what you are doing. Changing these may need additional
+steps to avoid breakage. Be sure to
+[allow plaintext authentication in dovecot](#Allow-plaintext-authentication-for-the-php-fpm-container-without-using-TLS)
+in this case as well.
 
 __NOTE:__ What will remain different between your installation and the current instructions is the use of a prefix on
 the roundcube database table names, i.e., the `db_prefix` option in roundcube's `config.inc.php` must remain set to the

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -18,7 +18,8 @@ Download Roundcube 1.6.x (check for latest release and adapt URL) to the web dir
 mkdir -m 755 data/web/rc
 wget -O - https://github.com/roundcube/roundcubemail/releases/download/1.6.1/roundcubemail-1.6.1-complete.tar.gz | tar -xvz --no-same-owner -C data/web/rc --strip-components=1 -f -
 docker exec -it $(docker ps -f name=php-fpm-mailcow -q) chown www-data:www-data /web/rc/logs /web/rc/temp
-docker exec -it $(docker ps -f name=php-fpm-mailcow -q) chmod 750 /web/rc/logs /web/rc/temp
+docker exec -it $(docker ps -f name=php-fpm-mailcow -q) chown root:www-data /web/rc/config
+docker exec -it $(docker ps -f name=php-fpm-mailcow -q) chmod 750 /web/rc/logs /web/rc/temp /web/rc/config
 ```
 
 ### Optional: Spellchecking

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -232,7 +232,7 @@ $config['plugins'] = array(
 );
 ```
 
-Configure the password plugin (be sure to adapt __**API_KEY**__ to you mailcow read/write API key):
+Configure the password plugin (be sure to adapt __\*\*API_KEY\*\*__ to you mailcow read/write API key):
 
 ```bash
 cat <<EOCONFIG >data/web/rc/plugins/password/config.inc.php

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -125,7 +125,7 @@ EOCONFIG
 ### Disable and remove installer
 
 Delete the directory `data/web/rc/installer` after a successful installation, and set the `enable_installer` option
-installation `data/web/rc/config/config.inc.php`!
+to false in `data/web/rc/config/config.inc.php`!
 
 ```bash
 rm -r data/web/rc/installer
@@ -414,6 +414,11 @@ composer in the container:
 docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer update --no-dev -o
 ```
 
+### Upgrade mime type mappings
+
+To upgrade the mime type mappings, re-download them using the command in the
+[installation instructions](#Install-mime-type-mappings).
+
 ## Uninstalling roundcube
 
 For the uninstallation, it is also assumed that the commands are executed in the mailcow installation directory and
@@ -532,3 +537,12 @@ in this case as well.
 __NOTE:__ What will remain different between your installation and the current instructions is the use of a prefix on
 the roundcube database table names, i.e., the `db_prefix` option in roundcube's `config.inc.php` must remain set to the
 used prefix. This is not a problem and there is no need to change the table names.
+
+### Removing roundcube tables from mailcow database
+
+After you have verified that the migration was successful and roundcube works using the separate database, you can remove
+the roundcube tables from the mailcow database using the following command:
+
+```bash
+docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -sN mailcow -e "SET SESSION foreign_key_checks = 0; DROP TABLE IF EXISTS $(echo $RCTABLES | sed -e 's/ \+/,/g');"
+```

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -209,6 +209,7 @@ Configure the password plugin (be sure to adapt __**API_KEY**__ to you mailcow r
 
 ```bash
 cat <<EOCONFIG >data/web/rc/plugins/password/config.inc.php
+<?php
 \$config['password_driver'] = 'mailcow';
 \$config['password_confirm_current'] = true;
 \$config['password_mailcow_api_host'] = 'http://nginx';

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -209,10 +209,10 @@ Configure the password plugin (be sure to adapt __**API_KEY**__ to you mailcow r
 
 ```bash
 cat <<EOCONFIG >data/web/rc/plugins/password/config.inc.php
-$config['password_driver'] = 'mailcow';
-$config['password_confirm_current'] = true;
-$config['password_mailcow_api_host'] = 'http://nginx';
-$config['password_mailcow_api_token'] = '**API_KEY**';
+\$config['password_driver'] = 'mailcow';
+\$config['password_confirm_current'] = true;
+\$config['password_mailcow_api_host'] = 'http://nginx';
+\$config['password_mailcow_api_token'] = '**API_KEY**';
 EOCONFIG
 ```
 


### PR DESCRIPTION
Hello,

 I am in the process of migrating my mail server to mailcow, and as part of it I installed roundcube because it is my preferred webmailer.

Originally I just intended to update the mailcow instructions regarding the CardDAV plugin (of which I am the author), because the current version 5 supports some features like rediscovery of added or removed addressbooks on the server that are of interest in combination with SOGo, but I thought other parts of the setup could be improved as well, so the changes are a bit bigger.

Main changes:
- Use separate database for roundcube
- Download mime.types once and not on every container start
- Use mailcow API for password change from roundcube instead of direct database access
- Use non-TLS connection instead of TLS with disabled certificate check
- Upgrade CardDAV instructions to use RCMCardDAV v5 which also includes rediscovery of new/removed server-side addressbooks
- Instructions for forwarding client IP to dovecot (main benefit: netfilter container acts on excessive failed logins)
- Composer is already part of the php-fpm container, so we can use it to install plugins and also no need to download it for updating roundcube.

I did not try the admin login part into roundcube because it is of no interest to me, so I just kept the existing text. I also did not try the upgrade part but it looks fine to me from what I am used to when upgrading roundcube.

I can also update the German instructions, but I would first like to gather feedback on the English version and update the German one when there is agreement on the English variant.