### PR TITLE
Corrected roundcube password change guide

### DIFF
--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -89,6 +89,14 @@ $config['plugins'] = array(
 );
 [...]
 ```
+Fügen Sie am Ende der Datei die folgenden Parameter hinzu:
+
+```php
+$config['password_driver'] = 'sql';
+$config['password_algorithm'] = 'ssha256';
+$config['password_algorithm_prefix'] = '{SSHA256}';
+$config['password_query'] = "UPDATE mailbox SET password = %P WHERE username = %u";
+```
 
 Öffnen Sie `data/web/rc/plugins/password/password.php`, suchen Sie nach `case 'ssha':` und fügen Sie oben hinzu:
 
@@ -98,15 +106,6 @@ $config['plugins'] = array(
             $crypted = base64_encode( hash('sha256', $password . $salt, TRUE ) . $salt );
             $prefix  = '{SSHA256}';
             break;
-```
-
-Öffnen Sie `data/web/rc/plugins/password/config.inc.php` und ändern Sie die folgenden Parameter (oder fügen Sie sie am Ende der Datei hinzu):
-
-```php
-$config['password_driver'] = 'sql';
-$config['password_algorithm'] = 'ssha256';
-$config['password_algorithm_prefix'] = '{SSHA256}';
-$config['password_query'] = "UPDATE mailbox SET password = %P WHERE username = %u";
 ```
 
 ## CardDAV Adressbücher in Roundcube einbinden

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -90,6 +90,15 @@ $config['plugins'] = array(
 ...
 ```
 
+Add the following parameters to the bottom of the file:
+
+```php
+$config['password_driver'] = 'sql';
+$config['password_algorithm'] = 'ssha256';
+$config['password_algorithm_prefix'] = '{SSHA256}';
+$config['password_query'] = "UPDATE mailbox SET password = %P WHERE username = %u";
+```
+
 Open `data/web/rc/plugins/password/password.php`, search for `case 'ssha':` and add above:
 
 ```php
@@ -98,15 +107,6 @@ Open `data/web/rc/plugins/password/password.php`, search for `case 'ssha':` and 
             $crypted = base64_encode( hash('sha256', $password . $salt, TRUE ) . $salt );
             $prefix  = '{SSHA256}';
             break;
-```
-
-Open `data/web/rc/plugins/password/config.inc.php` and change the following parameters (or add them at the bottom of that file):
-
-```php
-$config['password_driver'] = 'sql';
-$config['password_algorithm'] = 'ssha256';
-$config['password_algorithm_prefix'] = '{SSHA256}';
-$config['password_query'] = "UPDATE mailbox SET password = %P WHERE username = %u";
 ```
 
 ## Integrate CardDAV addressbooks in Roundcube


### PR DESCRIPTION
Roundcube no longer parses plugin config files.
Adding the config parameters to the main configuration files fixes it.