### PR TITLE
Updating the Postgres DSN in Mailman3 Doc

### DIFF
--- a/docs/third_party/mailman3/third_party-mailman3.de.md
+++ b/docs/third_party/mailman3/third_party-mailman3.de.md
@@ -212,7 +212,7 @@ version: '2'
 services:
   mailman-core:
     environment:
-    - DATABASE_URL=postgres://mailman:DBPASS@database/mailmandb
+    - DATABASE_URL=postgresql://mailman:DBPASS@database/mailmandb
     - HYPERKITTY_API_KEY=HYPERKITTY_KEY
     - TZ=Europe/Berlin
     - MTA=postfix
@@ -222,7 +222,7 @@ services:
 
   mailman-web:
     environment:
-    - DATABASE_URL=postgres://mailman:DBPASS@database/mailmandb
+    - DATABASE_URL=postgresql://mailman:DBPASS@database/mailmandb
     - HYPERKITTY_API_KEY=HYPERKITTY_KEY
     - TZ=Europe/Berlin
     - SECRET_KEY=DJANGO_KEY

--- a/docs/third_party/mailman3/third_party-mailman3.en.md
+++ b/docs/third_party/mailman3/third_party-mailman3.en.md
@@ -212,7 +212,7 @@ version: '2'
 services:
   mailman-core:
     environment:
-    - DATABASE_URL=postgres://mailman:DBPASS@database/mailmandb
+    - DATABASE_URL=postgresql://mailman:DBPASS@database/mailmandb
     - HYPERKITTY_API_KEY=HYPERKITTY_KEY
     - TZ=Europe/Berlin
     - MTA=postfix
@@ -222,7 +222,7 @@ services:
 
   mailman-web:
     environment:
-    - DATABASE_URL=postgres://mailman:DBPASS@database/mailmandb
+    - DATABASE_URL=postgresql://mailman:DBPASS@database/mailmandb
     - HYPERKITTY_API_KEY=HYPERKITTY_KEY
     - TZ=Europe/Berlin
     - SECRET_KEY=DJANGO_KEY


### PR DESCRIPTION
After deploying the Mailman3 containers, I faced an error regarding the connection to the Postgres container. Digging into it, it appears that the sqlalchemy library doesn't support using `postgres` any more, but uses `postgresql` instead. This fixes the documentation.