### PR TITLE
Borgmatic config update

### DIFF
--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -65,24 +65,21 @@ Als nächstes müssen wir die borgmatic-Konfiguration erstellen.
 ```shell
 source mailcow.conf
 cat <<EOF > data/conf/borgmatic/etc/config.yaml
-location:
     source_directories:
         - /mnt/source
     repositories:
-        - ssh://user@rsync.net:22/./mailcow
+    - path: ssh://user@rsync.net:22/./mailcow
+      label: rsync
     exclude_patterns:
         - '/mnt/source/postfix/public/'
         - '/mnt/source/postfix/private/'
         - '/mnt/source/rspamd/rspamd.sock'
 
-retention:
     keep_hourly: 24
     keep_daily: 7
     keep_weekly: 4
     keep_monthly: 6
-    prefix: ""
 
-hooks:
     mysql_databases:
         - name: ${DBNAME}
           username: ${DBUSER}

--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -65,26 +65,26 @@ Als nächstes müssen wir die borgmatic-Konfiguration erstellen.
 ```shell
 source mailcow.conf
 cat <<EOF > data/conf/borgmatic/etc/config.yaml
-    source_directories:
-        - /mnt/source
-    repositories:
+source_directories:
+    - /mnt/source
+repositories:
     - path: ssh://user@rsync.net:22/./mailcow
       label: rsync
-    exclude_patterns:
-        - '/mnt/source/postfix/public/'
-        - '/mnt/source/postfix/private/'
-        - '/mnt/source/rspamd/rspamd.sock'
+exclude_patterns:
+    - '/mnt/source/postfix/public/'
+    - '/mnt/source/postfix/private/'
+    - '/mnt/source/rspamd/rspamd.sock'
 
-    keep_hourly: 24
-    keep_daily: 7
-    keep_weekly: 4
-    keep_monthly: 6
+keep_hourly: 24
+keep_daily: 7
+keep_weekly: 4
+keep_monthly: 6
 
-    mysql_databases:
-        - name: ${DBNAME}
-          username: ${DBUSER}
-          password: ${DBPASS}
-          options: --default-character-set=utf8mb4
+mysql_databases:
+    - name: ${DBNAME}
+        username: ${DBUSER}
+        password: ${DBPASS}
+        options: --default-character-set=utf8mb4
 EOF
 ```
 
@@ -100,9 +100,6 @@ Schauen Sie in der [borgmatic Dokumentation](https://torsion.org/borgmatic/) nac
 Konfigurationsoptionen. Wenn Sie ein lokales Dateisystem als Backup-Ziel verwenden, stellen Sie sicher, dass Sie es in den
 Container einbinden. Der Container definiert zu diesem Zweck ein Volume namens `/mnt/borg-repository`.
 
-!!! note
-    Wenn Sie rsync.net nicht verwenden, können Sie wahrscheinlich das Element `remote_path` aus Ihrer Konfiguration streichen.
-	
 ### Erstellen Sie einen crontab
 
 Erstellen Sie eine neue Textdatei in `data/conf/borgmatic/etc/crontab.txt` mit folgendem Inhalt:

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -66,26 +66,26 @@ Next, we need to create the borgmatic configuration.
 ```shell
 source mailcow.conf
 cat <<EOF > data/conf/borgmatic/etc/config.yaml
-    source_directories:
-        - /mnt/source
-    repositories:
+source_directories:
+    - /mnt/source
+repositories:
     - path: ssh://user@rsync.net:22/./mailcow
       label: rsync
-    exclude_patterns:
-        - '/mnt/source/postfix/public/'
-        - '/mnt/source/postfix/private/'
-        - '/mnt/source/rspamd/rspamd.sock'
+exclude_patterns:
+    - '/mnt/source/postfix/public/'
+    - '/mnt/source/postfix/private/'
+    - '/mnt/source/rspamd/rspamd.sock'
 
-    keep_hourly: 24
-    keep_daily: 7
-    keep_weekly: 4
-    keep_monthly: 6
+keep_hourly: 24
+keep_daily: 7
+keep_weekly: 4
+keep_monthly: 6
 
-    mysql_databases:
-        - name: ${DBNAME}
-          username: ${DBUSER}
-          password: ${DBPASS}
-          options: --default-character-set=utf8mb4
+mysql_databases:
+    - name: ${DBNAME}
+        username: ${DBUSER}
+        password: ${DBPASS}
+        options: --default-character-set=utf8mb4
 EOF
 ```
 
@@ -100,9 +100,6 @@ year.
 Check the [borgmatic documentation](https://torsion.org/borgmatic/) on how to use other types of repositories or
 configuration options. If you choose to use a local filesystem as a backup destination make sure to mount it into the
 container. The container defines a volume called `/mnt/borg-repository` for this purpose.
-
-!!! note
-    If you do not use rsync.net you can most likely drop the `remote_path` element from your config.
 
 ### Create a crontab
 

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -66,24 +66,21 @@ Next, we need to create the borgmatic configuration.
 ```shell
 source mailcow.conf
 cat <<EOF > data/conf/borgmatic/etc/config.yaml
-location:
     source_directories:
         - /mnt/source
     repositories:
-        - ssh://user@rsync.net:22/./mailcow
+    - path: ssh://user@rsync.net:22/./mailcow
+      label: rsync
     exclude_patterns:
         - '/mnt/source/postfix/public/'
         - '/mnt/source/postfix/private/'
         - '/mnt/source/rspamd/rspamd.sock'
 
-retention:
     keep_hourly: 24
     keep_daily: 7
     keep_weekly: 4
     keep_monthly: 6
-    prefix: ""
 
-hooks:
     mysql_databases:
         - name: ${DBNAME}
           username: ${DBUSER}


### PR DESCRIPTION
After running some maintenance tasks on my borgmatic backup, I noticed the following warning messages:
![image](https://github.com/mailcow/mailcow-dockerized-docs/assets/41271480/16150b12-b3b3-4424-9711-14bd14cab9f9)

The changes to the config file in this pull request resolve these deprecation warnings.

I've also removed a note about if you use rsync you can likely remove a remote_path config element as this element already doesn't exist in the config file.

Lastly, I've made the same chnages to the German documentation.