### PR TITLE
fix borgmatic config

### DIFF
--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -82,9 +82,9 @@ keep_monthly: 6
 
 mysql_databases:
     - name: ${DBNAME}
-        username: ${DBUSER}
-        password: ${DBPASS}
-        options: --default-character-set=utf8mb4
+      username: ${DBUSER}
+      password: ${DBPASS}
+      options: --default-character-set=utf8mb4
 EOF
 ```
 

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -83,9 +83,9 @@ keep_monthly: 6
 
 mysql_databases:
     - name: ${DBNAME}
-        username: ${DBUSER}
-        password: ${DBPASS}
-        options: --default-character-set=utf8mb4
+      username: ${DBUSER}
+      password: ${DBPASS}
+      options: --default-character-set=utf8mb4
 EOF
 ```
 


### PR DESCRIPTION
remove some space on mysql dump hooks because it is causing "mapping values are not allowed in this context" error.