### PR TITLE
Updates u_e-mailcow_ui-bl_wl.de 

### DIFF
--- a/docs/manual-guides/mailcow-UI/u_e-mailcow_ui-bl_wl.de.md
+++ b/docs/manual-guides/mailcow-UI/u_e-mailcow_ui-bl_wl.de.md
@@ -1,4 +1,4 @@
-Um einen Eintrag zu Ihrer **domainübergreifenden** Filtertabelle hinzuzufügen oder zu bearbeiten, loggen Sie sich als (Domain-)Administrator in Ihre *mailcow UI* ein und wechseln Sie zu: 
+Um einen Eintrag zu Ihrer **domain-weiten** Filtertabelle hinzuzufügen oder zu bearbeiten, loggen Sie sich als (Domain-)Administrator in Ihre *mailcow UI* ein und wechseln Sie zu: 
 `Konfiguration > E-Mail-Setup > Domains > (Domain) Bearbeiten > Spamfilter`.
 
 ![Black- und Whitelist Konfiguration](../../assets/images/manual-guides/mailcow-bl_wl.png)
@@ -6,4 +6,4 @@ Um einen Eintrag zu Ihrer **domainübergreifenden** Filtertabelle hinzuzufügen 
 !!! Info
     Seien Sie sich bewusst, dass ein Benutzer diese [Einstellung](u_e-mailcow_ui-spamfilter.md) überschreiben kann, indem er seine eigene Black- und Whitelist setzt!
 
-Es ist auch eine globale Filtertabelle in `Konfiguration > Server-Konfiguration > Globale Filter-Maps` verfügbar, um einen **serverübergreifenden** Filter für ein oder mehrere Regex-Maps zu konfigurieren (Todo: Screenshots).
+Es ist auch eine globale Filtertabelle in `Konfiguration > Server-Konfiguration > Globale Filter-Maps` verfügbar, um einen **server-weiten** (also domainübergreifenden) Filter für ein oder mehrere Regex-Maps zu konfigurieren (Todo: Screenshots).


### PR DESCRIPTION
to describe domain-wide and server-wide black/whitelists also in german version in the correct way.

"Domainübergreifend" beschreibt im deutschen das genaue Gegenteil von dem was in dem File gemeint war.