### PR TITLE
typo: add "

### DIFF
--- a/docs/third_party/gitea/third_party-gitea.de.md
+++ b/docs/third_party/gitea/third_party-gitea.de.md
@@ -5,7 +5,7 @@ Mit der Fähigkeit von Gitea, sich über SMTP zu authentifizieren, ist es trivia
 source mailcow.conf
 docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "CREATE DATABASE gitea;"
 docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "CREATE USER 'gitea'@'%' IDENTIFIED BY 'your_strong_password';"
-docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "GRANT ALL PRIVILEGES ON gitea.* TO 'gitea'@'%';
+docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "GRANT ALL PRIVILEGES ON gitea.* TO 'gitea'@'%';"
 ```
 
 2\. Öffnen Sie `docker-compose.override.yml` und fügen Sie Gitea hinzu:

--- a/docs/third_party/gitea/third_party-gitea.en.md
+++ b/docs/third_party/gitea/third_party-gitea.en.md
@@ -5,7 +5,7 @@ With Gitea' ability to authenticate over SMTP it is trivial to integrate it with
 source mailcow.conf
 docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "CREATE DATABASE gitea;"
 docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "CREATE USER 'gitea'@'%' IDENTIFIED BY 'your_strong_password';"
-docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "GRANT ALL PRIVILEGES ON gitea.* TO 'gitea'@'%';
+docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "GRANT ALL PRIVILEGES ON gitea.* TO 'gitea'@'%';"
 ```
 
 2\. Open `docker-compose.override.yml` and add gitea:


### PR DESCRIPTION
there was a missing " that was causing the command to not work successfully. 