### PR TITLE
Clarify need to use an app password for ActiveSync with 2FA enabled

### DIFF
--- a/docs/client/client-apple.de.md
+++ b/docs/client/client-apple.de.md
@@ -24,5 +24,5 @@ Unter iOS wird auch Exchange ActiveSync als Alternative zum obigen Verfahren unt
 
 1. Öffnen Sie die App *Einstellungen*, tippen Sie auf *Mail*, tippen Sie auf *Konten*, tippen Sie auf *Konto hinzufügen*, wählen Sie *Exchange*.
 2. Geben Sie Ihre E-Mail Adresse<span class="client_variables_available"> (<code><span class="client_var_email"></span></code>)</span> ein und tippen Sie auf *Weiter*.
-3. Geben Sie Ihr Passwort ein und tippen Sie erneut auf *Weiter*.
+3. Geben Sie Ihr Passwort ein und tippen Sie erneut auf *Weiter*. Wenn die 2-Faktor-Authentifizierung aktiviert ist, müssen Sie ein App-Password anstelle Ihres normalen Passwortes benutzen.
 4. Tippen Sie abschließend auf *Speichern*.

--- a/docs/client/client-apple.en.md
+++ b/docs/client/client-apple.en.md
@@ -24,5 +24,5 @@ On iOS, Exchange ActiveSync is also supported as an alternative to the procedure
 
 1. Open the *Settings* app, tap *Mail*, tap *Accounts*, tap *Add Acccount*, select *Exchange*.
 2. Enter your email address<span class="client_variables_available"> (<code><span class="client_var_email"></span></code>)</span> and tap *Next*.
-3. Enter your password, tap *Next* again.
+3. Enter your password, tap *Next* again. With 2-Factor-Authentication enabled, you have to use an App password instead of your regular password.
 4. Finally, tap *Save*.


### PR DESCRIPTION
Adds a notice that an App password has to be used to login with Exchange ActiveSync on Apple Devices if 2FA is enabled.