### PR TITLE
Create Borg Backup even when backing up mysql

### DIFF
--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -73,7 +73,6 @@ Das nächste Kommando erzeugt dann die borgmatic-Konfigurationsdatei mit den kor
 ```bash
 cat <<EOF > data/conf/borgmatic/etc/config.yaml
 source_directories:
-    - /mnt/source
     - /mnt/source/vmail
     - /mnt/source/crypt
     - /mnt/source/redis

--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -74,6 +74,11 @@ Das nächste Kommando erzeugt dann die borgmatic-Konfigurationsdatei mit den kor
 cat <<EOF > data/conf/borgmatic/etc/config.yaml
 source_directories:
     - /mnt/source
+    - /mnt/source/vmail
+    - /mnt/source/crypt
+    - /mnt/source/redis
+    - /mnt/source/rspamd
+    - /mnt/source/postfix
 repositories:
     - path: ssh://user@rsync.net:22/./mailcow
       label: rsync

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -75,6 +75,12 @@ The next command then creates the borgmatic configuration file containing the co
 cat <<EOF > data/conf/borgmatic/etc/config.yaml
 source_directories:
     - /mnt/source
+    - /mnt/source
+    - /mnt/source/vmail
+    - /mnt/source/crypt
+    - /mnt/source/redis
+    - /mnt/source/rspamd
+    - /mnt/source/postfix
 repositories:
     - path: ssh://user@rsync.net:22/./mailcow
       label: rsync

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -75,7 +75,6 @@ The next command then creates the borgmatic configuration file containing the co
 cat <<EOF > data/conf/borgmatic/etc/config.yaml
 source_directories:
     - /mnt/source
-    - /mnt/source
     - /mnt/source/vmail
     - /mnt/source/crypt
     - /mnt/source/redis

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -74,7 +74,6 @@ The next command then creates the borgmatic configuration file containing the co
 ```bash
 cat <<EOF > data/conf/borgmatic/etc/config.yaml
 source_directories:
-    - /mnt/source
     - /mnt/source/vmail
     - /mnt/source/crypt
     - /mnt/source/redis


### PR DESCRIPTION
Hello,

regarding this forum thread: https://community.mailcow.email/d/1796-borgmatic-does-not-backup-vmail/ Borgmatic isn't backing up everything when also dumping the database using a hook because of the `one_file_system: true` setting.

Adding the mounted volumes explicitly to the list solves this issue.