### PR TITLE
feat: add ACME rules to HAProxy config example

### DIFF
--- a/docs/post_installation/reverse-proxy/r_p-haproxy.de.md
+++ b/docs/post_installation/reverse-proxy/r_p-haproxy.de.md
@@ -4,11 +4,18 @@
 !!! warning "Warnung"
     Dies ist ein nicht unterstützter Community Beitrag. Korrekturen sind immer erwünscht!
 
-**Wichtig/Fix erwünscht**: Dieses Beispiel leitet nur HTTPS-Verkehr weiter und benutzt nicht den in mailcow eingebauten ACME-Client.
+Dieses Beispiel leitet den gesamten HTTP-Verkehr zu HTTPS um, außer für den eingebauten ACME-Client von mailcow.
+Wenn Sie den eingebauten ACME-Client nicht verwenden möchten, ändern Sie bitte die Konfiguration selbst.
 
 ```
 frontend https-in
+  bind :::80 v4v6
   bind :::443 v4v6 ssl crt mailcow.pem
+
+  acl mailcow_acme path -i -m beg /.well-known/
+
+  redirect scheme https unless { ssl_fc || mailcow_acme }
+
   default_backend mailcow
 
 backend mailcow

--- a/docs/post_installation/reverse-proxy/r_p-haproxy.en.md
+++ b/docs/post_installation/reverse-proxy/r_p-haproxy.en.md
@@ -4,11 +4,18 @@
 !!! warning
     This is an unsupported community contribution. Feel free to provide fixes.
 
-**Important/Fixme**: This example only forwards HTTPS traffic and does not use mailcows built-in ACME client.
+This example redirects all HTTP traffic to HTTPS except for mailcow's built-in ACME client.
+If you do not want to use the built-in ACME client, please modify the configuration yourself.
 
 ```
 frontend https-in
+  bind :::80 v4v6
   bind :::443 v4v6 ssl crt mailcow.pem
+
+  acl mailcow_acme path -i -m beg /.well-known/
+
+  redirect scheme https unless { ssl_fc || mailcow_acme }
+
   default_backend mailcow
 
 backend mailcow


### PR DESCRIPTION
Updated the HAProxy config example. I think it is now more handy.

However, I need help with the German version because I don't know German.