### PR TITLE
Update minimum docker version requirements

### DIFF
--- a/docs/getstarted/install.de.md
+++ b/docs/getstarted/install.de.md
@@ -3,7 +3,7 @@
 
 ## Docker und Docker Compose Installation
 
-Sie benötigen Docker (eine Version >= `27.0.0` ist erforderlich) und Docker Compose (eine Version `>= 2.0` ist erforderlich).
+Sie benötigen Docker (eine Version >= `24.0.0` ist erforderlich) und Docker Compose (eine Version `>= 2.0` ist erforderlich).
 
 Erfahren Sie, wie Sie [Docker](https://docs.docker.com/install/) und [Docker Compose](https://docs.docker.com/compose/install/) installieren.
 

--- a/docs/getstarted/install.de.md
+++ b/docs/getstarted/install.de.md
@@ -3,7 +3,7 @@
 
 ## Docker und Docker Compose Installation
 
-Sie benötigen Docker (eine Version >= `20.10.2` ist erforderlich) und Docker Compose (eine Version `>= 2.0` ist erforderlich).
+Sie benötigen Docker (eine Version >= `27.0.0` ist erforderlich) und Docker Compose (eine Version `>= 2.0` ist erforderlich).
 
 Erfahren Sie, wie Sie [Docker](https://docs.docker.com/install/) und [Docker Compose](https://docs.docker.com/compose/install/) installieren.
 

--- a/docs/getstarted/install.en.md
+++ b/docs/getstarted/install.en.md
@@ -2,7 +2,7 @@
     The installation is exactly the same on x86 and ARM64 platforms!
 
 ## Docker and Docker Compose Installation
-You need Docker (a version >= `20.10.2` is required) and Docker Compose (a version `>= 2.0` is required).
+You need Docker (a version >= `27.0.0` is required) and Docker Compose (a version `>= 2.0` is required).
 
  Learn how to install [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
 

--- a/docs/getstarted/install.en.md
+++ b/docs/getstarted/install.en.md
@@ -2,7 +2,7 @@
     The installation is exactly the same on x86 and ARM64 platforms!
 
 ## Docker and Docker Compose Installation
-You need Docker (a version >= `27.0.0` is required) and Docker Compose (a version `>= 2.0` is required).
+You need Docker (a version >= `24.0.0` is required) and Docker Compose (a version `>= 2.0` is required).
 
  Learn how to install [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
 


### PR DESCRIPTION
Just updated the version numbers to the current major version. With the old `20.10.2`, mailcow doesn't start correctly anymore.

Maybe older versions (like version 25 or 26) are also working, I didn't test for the oldest working version.