### PR TITLE
Improved "Forward the client network address to dovecot"

### DIFF
--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -320,7 +320,7 @@ Erzeugung der Datenbank-Tabellen bzw. Änderungen nur bei der Anmeldung in Round
 ### Übermittlung der Client-Netzwerkadresse an Dovecot
 
 Normalerweise sieht der IMAP-Server Dovecot die Netzwerkadresse des php-fpm-Containers wenn Roundcube zu diesem
-Verbindungen aufbaut. Durch Verwendung einer IMAP-Erweiterung und dem `roundcube-dovecot_client_ip` Roundcube-Plugin ist
+Verbindungen aufbaut. Durch Verwendung einer IMAP-Erweiterung und dem `dovecot_client_ip` Roundcube-Plugin ist
 es möglich, dass Roundcube Dovecot die Client-Netzwerkadresse übermittelt, so dass in den Log-Dateien die
 Client-Netzwerkadresse erscheint. Dies führt dazu, dass Login-Versuche an Roundcube in den Dovecot-Logs genauso wie
 direkte Client-Verbindungen zu Dovecot aufgezeichnet werden, und fehlgeschlagene Login-Versuche an Roundcube
@@ -330,8 +330,17 @@ Clients führen.
 
 Hierzu muss das Roundcube-Plugin installiert werden:
 
+
 ```bash
-docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer require --update-no-dev -o "takerukoushirou/roundcube-dovecot_client_ip:~1"
+docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer require --update-no-dev -o "foorschtbar/dovecot_client_ip:~2"
+```
+
+Bearbeiten Sie die Datei `data/web/rc/config/config.inc.php` und fügen Sie den folgenden Inhalt ein:
+
+```bash
+cat <<EOCONFIG >>data/web/rc/config/config.inc.php
+\$config['dovecot_client_ip_trusted_proxies'] = ['${IPV4_NETWORK}.0/24', '${IPV6_NETWORK}'];
+EOCONFIG
 ```
 
 Weiterhin müssen wir Dovecot konfigurieren, so dass der php-fpm-Container als Teil eines vertrauenswürdigen Netzwerks

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -300,7 +300,7 @@ during the login to roundcube.
 ### Forward the client network address to dovecot
 
 Normally, the IMAP server dovecot will see the network address of the php-fpm container when roundcube interacts with the IMAP
-server. Using an IMAP extension and the `roundcube-dovecot_client_ip` roundcube plugin, it is possible for roundcube to tell
+server. Using an IMAP extension and the `dovecot_client_ip` roundcube plugin, it is possible for roundcube to tell
 dovecot the client IP, so it will also show up in the logs as the remote IP. When doing this, login attempts will show in the
 dovecot logs like any direct client connections to dovecot, and such failed logins into roundcube will be treated in the same
 manner as failed direct IMAP logins, causing blocking of the client with the netfilter container or other mechanisms that may
@@ -309,7 +309,15 @@ already be in place to handle bruteforce attacks on the IMAP server.
 For this, the roundcube plugin must be installed.
 
 ```bash
-docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer require --update-no-dev -o "takerukoushirou/roundcube-dovecot_client_ip:~1"
+docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer require --update-no-dev -o "foorschtbar/dovecot_client_ip:~2"
+```
+
+Edit the file `data/web/rc/config/config.inc.php` and insert the following content:
+
+```bash
+cat <<EOCONFIG >>data/web/rc/config/config.inc.php
+\$config['dovecot_client_ip_trusted_proxies'] = ['${IPV4_NETWORK}.0/24', '${IPV6_NETWORK}'];
+EOCONFIG
 ```
 
 Furthermore, we must configure dovecot to treat the php-fpm container as part of a trusted network so it is allowed to override
@@ -623,7 +631,7 @@ You must also adapt the configuration of the roundcube password plugin according
 you use the password changing functionality, since the old instruction directly changed the password in the database,
 whereas this version of the instruction uses the mailcow API for the password change.
 
-Regarding other changes and additions (e.g., roundcube-dovecot\_client\_ip plugin), you can go through the current
+Regarding other changes and additions (e.g., dovecot_client_ip plugin), you can go through the current
 installation instructions and adapt your configuration accordingly or perform the listed installation steps for new
 additions.
 


### PR DESCRIPTION
The original manual won't work, because the step of configure the plugin is missing AND the original plugin only support fixed addresses and no networks.

- Replaced roundcube-dovecot_client_ip with fork (with CIDR support)
- Added important configuration step to add trusted proxies (without this step it wont work!)