### PR TITLE
Improved Borgmatic tutorial

### DIFF
--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -40,7 +40,10 @@ services:
       - ./data/conf/borgmatic/ssh:/root/.ssh:Z
     environment:
       - TZ=${TZ}
-      - BORG_PASSPHRASE=YouBetterPutSomethingRealGoodHere
+      - BORG_PASSPHRASE=${BORG_PASSPHRASE}
+      - DBNAME=${DBNAME}
+      - DBUSER=${DBUSER}
+      - DBPASS=${DBPASS}
     networks:
       mailcow-network:
         aliases:
@@ -51,22 +54,16 @@ volumes:
   borg-config-vol-1:
 ```
 
-Stellen Sie sicher, dass Sie die `BORG_PASSPHRASE` in eine sichere Passphrase Ihrer Wahl ändern.
+Fügen Sie `BORG_PASSPHRASE=YouBetterPutSomethingRealGoodHere` zu Ihrer `mailcow.conf` hinzu und stellen Sie sicher, dass Sie die `BORG_PASSPHRASE` in eine sichere Passphrase Ihrer Wahl ändern.
 
 Aus Sicherheitsgründen mounten wir das maildir als schreibgeschützt. Wenn Sie später Daten wiederherstellen wollen,
 müssen Sie das `ro`-Flag entfernen, bevor Sie die Daten wiederherstellen. Dies wird im Abschnitt über die Wiederherstellung von Backups beschrieben.
 
 ### Erstellen Sie `data/conf/borgmatic/etc/config.yaml`
 
-Als nächstes müssen wir die borgmatic-Konfiguration erzeugen. Das Erstellen der Datei auf die hier beschriebene Weise stellt sicher, dass die korrekten MySQL-Zugangsdaten aus `mailcow.conf` übernommen werden.
+Als nächstes müssen wir die borgmatic-Konfiguration erzeugen. Borgmatic unterstützt Umgebungsvariableninterpolation, dadurch erhalten wir die korrekten MySQL-Zugangsdaten über Docker bzw. über unsere `mailcow.conf`, ohne dass diese in der Konfigurationsdatei offengelegt werden.
 
-Zunächst laden wir `mailcow.conf`, um Zugriff auf die mailcow-Einstellungen innerhalb des nachfolgenden Kommandos zu erhalten.
-
-```bash
-source mailcow.conf
-```
-
-Das nächste Kommando erzeugt dann die borgmatic-Konfigurationsdatei mit den korrekten Zugangsdaten. Vergewissern Sie sich, alle folgenden Zeilen zu kopieren!
+Vergewissern Sie sich, alle folgenden Zeilen zu kopieren!
 
 ```bash
 cat <<EOF > data/conf/borgmatic/etc/config.yaml

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -41,7 +41,10 @@ services:
       - ./data/conf/borgmatic/ssh:/root/.ssh:Z
     environment:
       - TZ=${TZ}
-      - BORG_PASSPHRASE=YouBetterPutSomethingRealGoodHere
+      - BORG_PASSPHRASE=${BORG_PASSPHRASE}
+      - DBNAME=${DBNAME}
+      - DBUSER=${DBUSER}
+      - DBPASS=${DBPASS}
     networks:
       mailcow-network:
         aliases:
@@ -52,22 +55,16 @@ volumes:
   borg-config-vol-1:
 ```
 
-Ensure that you change the `BORG_PASSPHRASE` to a secure passphrase of your choosing.
+Append `BORG_PASSPHRASE=YouBetterPutSomethingRealGoodHere` to your `mailcow.conf` and ensure that you change the `BORG_PASSPHRASE` to a secure passphrase of your choosing.
 
 For security reasons we mount the maildir as read-only. If you later want to restore data you will need to remove
 the `ro` flag prior to restoring the data. This is described in the section on restoring backups.
 
 ### Create `data/conf/borgmatic/etc/config.yaml`
 
-Next, we need to create the borgmatic configuration. Creating the file in this way ensures the correct MySQL credentials are pulled in from `mailcow.conf`.
+Next, we need to create the borgmatic configuration. Borgmatic supports environment variable interpolation, this way we can get the correct MySQL credentials from Docker or more specifically from our `mailcow.conf` without exposing them in our config.
 
-First we load `mailcow.conf` so we have access to the mailcow configuration settings for the following command.
-
-```bash
-source mailcow.conf
-```
-
-The next command then creates the borgmatic configuration file containing the correct credentials. Make sure to copy all the following lines!
+Make sure to copy all the following lines!
 
 ```bash
 cat <<EOF > data/conf/borgmatic/etc/config.yaml


### PR DESCRIPTION
The old Borgmatic tutorial suggested to write the Borg passphrase in the Docker compose file and to use credentials in the config file directly. Those files are readable by anyone by default and there was no mention of `chmod 600` them.
I changed the tutorial using Docker env vars and Borgmatic env var interpolation, so we can use `mailcow.conf` as a single entrypoint for credentials.