### PR TITLE
Rework client config guide for Apple devices.

### DIFF
--- a/docs/client/client-apple.de.md
+++ b/docs/client/client-apple.de.md
@@ -1,28 +1,53 @@
-## Methode 1 über Mobileconfig
+## Methode 1: Konfigurationsprofil
 
-E-Mail, Kontakte und Kalender können auf Apple-Geräten automatisch konfiguriert werden, indem ein Profil installiert wird. Um ein Profil herunterzuladen, müssen Sie sich zuerst in der mailcow UI anmelden.
+E-Mail, Kontakte und Kalender können auf Apple-Geräten automatisch konfiguriert werden, indem ein Konfigurationsprofil installiert wird. Um ein solches Profil herunterzuladen, müssen Sie sich mit dem gewünschten E-Mail-Konto in der mailcow UI anmelden.
 
-## Methode 1.1: IMAP, SMTP und Cal/CardDAV
+## Methode 1.1: IMAP und SMTP
 
-Diese Methode konfiguriert IMAP, CardDAV und CalDAV.
+Diese Methode konfiguriert IMAP und SMTP für den Zugriff auf ein E-Mail-Konto.
 
-1. Downloaden und öffnen <span class="client_variables_unavailable">die Datei von <i>https://${MAILCOW_HOSTNAME}/mobileconfig.php</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php">mailcow.mobileconfig</a></span>.
-2. Geben Sie den Entsperrungscode (iPhone) oder das Computerpasswort (Mac) ein.
-3. Geben Sie Ihr E-Mail-Passwort dreimal ein, wenn Sie dazu aufgefordert werden.
+1. Öffnen Sie <span class="client_variables_unavailable"><i>https://${MAILCOW_HOSTNAME}/mobileconfig.php?only_email</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php?only_email">mailcow.mobileconfig</a></span> um ein individuelles Konfigurationsprofil herunterzuladen.
+2. Öffnen Sie das Profil auf Ihrem Mac, iPhone oder iPad und folgen Sie der Anleitung von Apple für Ihre Betriebssystemversion, um das Profil zu installieren:
+    - [Anleitung für macOS](https://support.apple.com/de-de/guide/mac-help/mh35561/mac)
+    - [Anleitung für iOS](https://support.apple.com/de-de/102400)
+3. Da das Profil nicht digital signiert ist, müssen Sie den entsprechenden Hinweis bei der Installation bestätigen. Wenn Sie dazu aufgefordert werden, geben Sie das Passwort Ihres E-Mail-Kontos ein.
 
-## Methode 1.2: IMAP, SMTP (kein DAV)
+## Methode 1.2: IMAP, SMTP und Cal/CardDAV
 
-Diese Methode konfiguriert nur IMAP und SMTP.
+Diese Methode konfiguriert neben dem E-Mail-Konto zusätzlich CardDAV (Adressbuch) und CalDAV (Kalender).
 
-1. Downloaden und öffnen Sie <span class="client_variables_unavailable">die Datei von <i>https://${MAILCOW_HOSTNAME}/mobileconfig.php?only_email</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php?only_email">mailcow.mobileconfig</a></span>.
-2. Geben Sie den Entsperrungscode (iPhone) oder das Computerpasswort (Mac) ein.
-3. Geben Sie Ihr E-Mail-Passwort dreimal ein, wenn Sie dazu aufgefordert werden.
+1. Öffnen Sie <span class="client_variables_unavailable"><i>https://${MAILCOW_HOSTNAME}/mobileconfig.php</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php">mailcow.mobileconfig</a></span> um ein individuelles Konfigurationsprofil herunterzuladen.
+2. Öffnen Sie das Profil auf Ihrem Mac, iPhone oder iPad und folgen Sie der Anleitung von Apple für Ihre Betriebssystemversion, um das Profil zu installieren:
+    - [Anleitung für macOS](https://support.apple.com/de-de/guide/mac-help/mh35561/mac)
+    - [Anleitung für iOS](https://support.apple.com/de-de/102400)
+3. Da das Profil nicht digital signiert ist, müssen Sie den entsprechenden Hinweis bei der Installation bestätigen. Wenn Sie dazu aufgefordert werden, geben Sie das Passwort Ihres E-Mail-Kontos ein.
 
-## Methode 2 (Exchange ActiveSync-Emulation)
+## Methode 1.3: IMAP und SMTP mit App-Passwort
 
-Unter iOS wird auch Exchange ActiveSync als Alternative zum obigen Verfahren unterstützt. Es hat den Vorteil, dass es Push-E-Mail unterstützt (d. h. Sie werden sofort über eingehende Nachrichten benachrichtigt), hat aber einige Einschränkungen, z. B. unterstützt es nicht mehr als drei E-Mail-Adressen pro Kontakt in Ihrem Adressbuch. Befolgen Sie die folgenden Schritte, wenn Sie stattdessen Exchange verwenden möchten.
+Diese Methode konfiguriert IMAP und SMTP für den Zugriff auf ein E-Mail-Konto. Es wird ein neues App-Passwort erzeugt und in das Profil eingefügt, damit bei der Einrichtung kein Passwort eingegeben werden muss. Geben Sie das Profil nicht weiter, da es einen vollständigen Zugriff auf Ihr Postfach ermöglicht.
 
-1. Öffnen Sie die App *Einstellungen*, tippen Sie auf *Mail*, tippen Sie auf *Konten*, tippen Sie auf *Konto hinzufügen*, wählen Sie *Exchange*.
+1. Öffnen Sie <span class="client_variables_unavailable"><i>https://${MAILCOW_HOSTNAME}/mobileconfig.php?only_email&app_password</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php?only_email&app_password">mailcow.mobileconfig</a></span> um ein individuelles Konfigurationsprofil herunterzuladen.
+2. Öffnen Sie das Profil auf Ihrem Mac, iPhone oder iPad und folgen Sie der Anleitung von Apple für Ihre Betriebssystemversion, um das Profil zu installieren:
+    - [Anleitung für macOS](https://support.apple.com/de-de/guide/mac-help/mh35561/mac)
+    - [Anleitung für iOS](https://support.apple.com/de-de/102400)
+3. Da das Profil nicht digital signiert ist, müssen Sie den entsprechenden Hinweis bei der Installation bestätigen.
+
+## Methode 1.4: IMAP, SMTP und Cal/CardDAV mit App-Passwort
+
+Diese Methode konfiguriert neben dem E-Mail-Konto zusätzlich CardDAV (Adressbuch) und CalDAV (Kalender). Es wird ein neues App-Passwort erzeugt und in das Profil eingefügt, damit bei der Einrichtung kein Passwort eingegeben werden muss. Geben Sie das Profil nicht weiter, da es einen vollständigen Zugriff auf Ihr Postfach ermöglicht.
+
+1. Öffnen Sie <span class="client_variables_unavailable"><i>https://${MAILCOW_HOSTNAME}/mobileconfig.php?app_password</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php?app_password">mailcow.mobileconfig</a></span> um ein individuelles Konfigurationsprofil herunterzuladen.
+2. Öffnen Sie das Profil auf Ihrem Mac, iPhone oder iPad und folgen Sie der Anleitung von Apple für Ihre Betriebssystemversion, um das Profil zu installieren:
+    - [Anleitung für macOS](https://support.apple.com/de-de/guide/mac-help/mh35561/mac)
+    - [Anleitung für iOS](https://support.apple.com/de-de/102400)
+3. Da das Profil nicht digital signiert ist, müssen Sie den entsprechenden Hinweis bei der Installation bestätigen.
+
+## Methode 2: Exchange ActiveSync-Emulation
+
+Unter iOS/iPadOS wird auch Exchange ActiveSync als Alternative zum obigen Verfahren unterstützt. Es hat den Vorteil, dass es Push-E-Mail unterstützt (d. h. Sie werden sofort über eingehende Nachrichten benachrichtigt), hat aber einige Einschränkungen, z. B. unterstützt es nicht mehr als drei E-Mail-Adressen pro Kontakt in Ihrem Adressbuch. Befolgen Sie die folgenden Schritte, wenn Sie stattdessen Exchange verwenden möchten.
+
+1. Folgen Sie der [Anleitung von Apple](https://support.apple.com/de-de/guide/iphone/iph44d1ae58a/ios) für Ihre Version von iOS/iPadOS und wählen Sie *Microsoft Exchange* als E-Mail-Dienst.
 2. Geben Sie Ihre E-Mail Adresse<span class="client_variables_available"> (<code><span class="client_var_email"></span></code>)</span> ein und tippen Sie auf *Weiter*.
-3. Geben Sie Ihr Passwort ein und tippen Sie erneut auf *Weiter*. Wenn die 2-Faktor-Authentifizierung aktiviert ist, müssen Sie ein App-Password anstelle Ihres normalen Passwortes benutzen.
-4. Tippen Sie abschließend auf *Speichern*.
+3. Wählen Sie *Manuell konfigurieren* bei der Frage, ob die E-Mail-Adresse an Microsoft gesendet werden soll.
+4. Geben Sie Ihr Passwort ein und tippen Sie erneut auf *Weiter*. Wenn die 2-Faktor-Authentifizierung aktiviert ist, müssen Sie ein App-Password anstelle Ihres normalen Passwortes benutzen.
+5. Tippen Sie abschließend auf *Speichern*.

--- a/docs/client/client-apple.en.md
+++ b/docs/client/client-apple.en.md
@@ -1,28 +1,53 @@
-## Method 1 via Mobileconfig
+## Method 1: Configuration Profile
 
-Email, contacts and calendars can be configured automatically on Apple devices by installing a profile. To download a profile you must login to the mailcow UI first.
+Email, contacts and calendars can be configured automatically on Apple devices by installing a configuration profile. To download such a profile you must login to the mailcow UI with the desired email account first.
 
-## Method 1.1: IMAP, SMTP and Cal/CardDAV
+## Method 1.1: IMAP and SMTP
 
-This method configures IMAP, CardDAV and CalDAV.
+This method configures IMAP and SMTP to access an email account.
 
-1. Download and open <span class="client_variables_unavailable">the file from <i>https://${MAILCOW_HOSTNAME}/mobileconfig.php</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php">mailcow.mobileconfig</a></span>.
-2. Enter the unlock code (iPhone) or computer password (Mac).
-3. Enter your email password three times when prompted.
+1. Open <span class="client_variables_unavailable"> <i>https://${MAILCOW_HOSTNAME}/mobileconfig.php?only_email</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php?only_email">mailcow.mobileconfig</a></span> to download a customized configuration profile.
+2. Open the profile on your Mac, iPhone or iPad and follow Apple's instructions for your operating system version to install the profile:
+    - [Steps for macOS](https://support.apple.com/en-us/guide/mac-help/mh35561/mac)
+    - [Steps for iOS](https://support.apple.com/en-us/102400)
+3. Since the profile is not digitally signed, you must confirm the respective notification during installation. Enter the password for your email account when asked.
 
-## Method 1.2: IMAP, SMTP (no DAV)
+## Method 1.2: IMAP, SMTP and Cal/CardDAV
 
-This method configures IMAP and SMTP only.
+This method configures CardDAV (address book) and CalDAV (calendar) in addition to the email account.
 
-1. Download and open <span class="client_variables_unavailable">the file from <i>https://${MAILCOW_HOSTNAME}/mobileconfig.php?only_email</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php?only_email">mailcow.mobileconfig</a></span>.
-2. Enter the unlock code (iPhone) or computer password (Mac).
-3. Enter your email password when prompted.
+1. Open <span class="client_variables_unavailable"> <i>https://${MAILCOW_HOSTNAME}/mobileconfig.php</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php">mailcow.mobileconfig</a></span> to download a customized configuration profile.
+2. Open the profile on your Mac, iPhone or iPad and follow Apple's instructions for your operating system version to install the profile:
+    - [Steps for macOS](https://support.apple.com/en-us/guide/mac-help/mh35561/mac)
+    - [Steps for iOS](https://support.apple.com/en-us/102400)
+3. Since the profile is not digitally signed, you must confirm the respective notification during installation. Enter the password for your email account when asked.
 
-## Method 2 (Exchange ActiveSync emulation)
+## Method 1.3: IMAP and SMTP with App Password
 
-On iOS, Exchange ActiveSync is also supported as an alternative to the procedure above. It has the advantage of supporting push email (i.e. you are immediately notified of incoming messages), but has some limitations, e.g. it does not support more than three email addresses per contact in your address book. Follow the steps below if you decide to use Exchange instead.
+This method configures IMAP and SMTP to access an email account. A new app password is generated and added to the profile so that no password needs to be entered when setting up your device. Please do not share the file as it grants full access to your mailbox.
 
-1. Open the *Settings* app, tap *Mail*, tap *Accounts*, tap *Add Acccount*, select *Exchange*.
+1. Open <span class="client_variables_unavailable"> <i>https://${MAILCOW_HOSTNAME}/mobileconfig.php?only_email&app_password</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php?only_email&app_password">mailcow.mobileconfig</a></span> to download a customized configuration profile.
+2. Open the profile on your Mac, iPhone or iPad and follow Apple's instructions for your operating system version to install the profile:
+    - [Steps for macOS](https://support.apple.com/en-us/guide/mac-help/mh35561/mac)
+    - [Steps for iOS](https://support.apple.com/en-us/102400)
+3. Since the profile is not digitally signed, you must confirm the respective notification during installation. Enter the password for your email account when asked.
+
+## Method 1.4: IMAP, SMTP and Cal/CardDAV with App Password
+
+This method configures CardDAV (address book) and CalDAV (calendar) in addition to the email account. A new app password is generated and added to the profile so that no password needs to be entered when setting up your device. Please do not share the file as it grants full access to your mailbox.
+
+1. Open <span class="client_variables_unavailable"> <i>https://${MAILCOW_HOSTNAME}/mobileconfig.php?app_password</i></span><span class="client_variables_available"><a class="client_var_link" href="mobileconfig.php?app_password">mailcow.mobileconfig</a></span> to download a customized configuration profile.
+2. Open the profile on your Mac, iPhone or iPad and follow Apple's instructions for your operating system version to install the profile:
+    - [Steps for macOS](https://support.apple.com/en-us/guide/mac-help/mh35561/mac)
+    - [Steps for iOS](https://support.apple.com/en-us/102400)
+3. Since the profile is not digitally signed, you must confirm the respective notification during installation. Enter the password for your email account when asked.
+
+## Method 2: Exchange ActiveSync emulation
+
+On iOS/iPadOS, Exchange ActiveSync is also supported as an alternative to the procedure above. It has the advantage of supporting push email (i.e. you are immediately notified of incoming messages), but has some limitations, e.g. it does not support more than three email addresses per contact in your address book. Follow the steps below if you decide to use Exchange instead.
+
+1. Follow [Apple's instructions](https://support.apple.com/en-us/guide/iphone/iph44d1ae58a/ios) for your version of iOS/iPadOS and select *Microsoft Exchange* as email service.
 2. Enter your email address<span class="client_variables_available"> (<code><span class="client_var_email"></span></code>)</span> and tap *Next*.
-3. Enter your password, tap *Next* again. With 2-Factor-Authentication enabled, you have to use an App password instead of your regular password.
-4. Finally, tap *Save*.
+3. Select *Manual Configuration* when asked if your mail address should be sent to Microsoft.
+4. Enter your password, tap *Next* again. With Two-factor authentication enabled, you have to use an app password instead of your regular password.
+5. Finally, tap *Save*.


### PR DESCRIPTION
The guide now refers to official Apple documentation since steps vary between different macOS / iOS versions. Also added steps for configuration profiles with app passwords.

This probably fixes #766 -- the steps described there don't work on macOS 15 (Sequoia) anymore, that's why I linked the Apple docs.