### PR TITLE
Remove duplicate `pip install` command

### DIFF
--- a/.github/workflows/renovate_check-build.yml
+++ b/.github/workflows/renovate_check-build.yml
@@ -17,7 +17,6 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get -y install python3-pip
-          pip install -r requirements.txt
           python -m venv venv
           source ./venv/bin/activate
           pip install -r requirements.txt


### PR DESCRIPTION
## Short Description

Remove duplicate `pip install -r` command, as it broke workflow.

___

This edit requested by @MAGICCC 