### PR TITLE
Change unused ENABLE_TLS_SNI variable to ENABLE_SSL_SNI

### DIFF
--- a/docs/post_installation/reverse-proxy/r_p.de.md
+++ b/docs/post_installation/reverse-proxy/r_p.de.md
@@ -37,7 +37,7 @@ Erzeugen Sie die betroffenen Container neu, indem Sie den folgenden Befehl ausf�
     Das Skript `generate_config.sh` kopiert die Snake-oil Zertifikate an den richtigen Ort, so dass die Dienste nicht aufgrund fehlender Dateien nicht starten können.
 
 !!! warning "Warnung"
-    Wenn Sie TLS SNI aktivieren (`ENABLE_TLS_SNI` in mailcow.conf), **müssen** die Zertifikatspfade in Ihrem Reverse-Proxy mit den korrekten Pfaden in `data/assets/ssl/{hostname}` übereinstimmen. Die Zertifikate werden in `data/assets/ssl/{hostname1,hostname2,etc}` aufgeteilt und werden daher nicht funktionieren, wenn Sie die Beispiele von unten kopieren, die auf `data/assets/ssl/cert.pem` etc. zeigen.
+    Wenn Sie TLS SNI aktivieren (`ENABLE_SSL_SNI` in mailcow.conf), **müssen** die Zertifikatspfade in Ihrem Reverse-Proxy mit den korrekten Pfaden in `data/assets/ssl/{hostname}` übereinstimmen. Die Zertifikate werden in `data/assets/ssl/{hostname1,hostname2,etc}` aufgeteilt und werden daher nicht funktionieren, wenn Sie die Beispiele von unten kopieren, die auf `data/assets/ssl/cert.pem` etc. zeigen.
 
 !!! info
     Die Verwendung der Konfigurationsbeispiele wird **acme-Anfragen an mailcow** weiterleiten und es die Zertifikate selbst verwalten lassen.

--- a/docs/post_installation/reverse-proxy/r_p.en.md
+++ b/docs/post_installation/reverse-proxy/r_p.en.md
@@ -37,7 +37,7 @@ Recreate affected containers by running the command:
     The script `generate_config.sh` copies snake-oil certificates to the correct location, so the services will not fail to start due to missing files.
 
 !!! warning
-    If you enable TLS SNI (`ENABLE_TLS_SNI` in mailcow.conf), the certificate paths in your reverse proxy **must** match the correct paths in `data/assets/ssl/{hostname}`. The certificates will be split into `data/assets/ssl/{hostname1,hostname2,etc}` and therefore will not work when you copy the examples from below pointing to `data/assets/ssl/cert.pem` etc.
+    If you enable TLS SNI (`ENABLE_SSL_SNI` in mailcow.conf), the certificate paths in your reverse proxy **must** match the correct paths in `data/assets/ssl/{hostname}`. The certificates will be split into `data/assets/ssl/{hostname1,hostname2,etc}` and therefore will not work when you copy the examples from below pointing to `data/assets/ssl/cert.pem` etc.
 
 !!! info
     Using the site configuration examples will **forward ACME requests to mailcow** and let it handle certificates itself.


### PR DESCRIPTION
In mailcow.conf, there is no ENABLE_TLS_SNI variable. The variable name is ENABLE_SSL_SNI in files (mailcow.conf and acme.sh)