### PR TITLE
Skip unsupported SSL DB connections in borgmatic.

### DIFF
--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -86,11 +86,12 @@ keep_daily: 7
 keep_weekly: 4
 keep_monthly: 6
 
-mysql_databases:
+mariadb_databases:
     - name: ${DBNAME}
       username: ${DBUSER}
       password: ${DBPASS}
-      options: --default-character-set=utf8mb4
+      options: "--default-character-set=utf8mb4 --skip-ssl"
+      list_options: "--skip-ssl"
 EOF
 ```
 
@@ -100,6 +101,11 @@ EOF
     des Borgmatic-Containers auf Deprecation-Warnmeldungen prüfen, um festzustellen, ob Sie betroffen sind und Ihre
     Konfigurationsdatei für eine ältere Version von borgmatic erstellt wurde. In diesem Fall sollten Sie eine neue
     `config.yaml`-Datei wie oben beschrieben erstellen, um Probleme mit zukünftigen Versionen von borgmatic zu vermeiden.
+
+!!! warning
+    Ab borgmatic 1.9.4 (erschienen am 11. Dezember 2024) versuchen die enthaltenen MariaDB-Tools standardmäßig, verschlüsselte Verbindungen
+    herzustellen. Bearbeiten Sie die `config.yaml` und fügen Sie `--skip-ssl` zu `options:` und `list_options:` wie oben gezeigt hinzu.
+    Ändern Sie außerdem `mysql_databases:` in `mariadb_databases:`, um Probleme mit zukünftigen Versionen von borgmatic und MariaDB zu vermeiden.
 
 Diese Datei ist ein minimales Beispiel für die Verwendung von borgmatic mit einem Konto `user` beim Cloud-Speicheranbieter `rsync.net` für
 ein Repository namens `mailcow` (siehe Einstellung `repositories`). Dies muss entsprechend angepasst werden.

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -87,11 +87,12 @@ keep_daily: 7
 keep_weekly: 4
 keep_monthly: 6
 
-mysql_databases:
+mariadb_databases:
     - name: ${DBNAME}
       username: ${DBUSER}
       password: ${DBPASS}
-      options: --default-character-set=utf8mb4
+      options: "--default-character-set=utf8mb4 --skip-ssl"
+      list_options: "--skip-ssl"
 EOF
 ```
 
@@ -101,6 +102,11 @@ EOF
     of the borgmatic container for deprecation warnings to see if you are affected, i.e. if your config file was
     generated for an older borgmatic version. In this case, you should create a new `config.yaml` file as described
     above to avoid problems with future borgmatic releases.
+
+!!! warning
+    Starting with borgmatic 1.9.4 (released December 11th, 2024), the included MariaDB tools try to force encrypted connections
+    by default. Edit your `config.yaml` and add `--skip-ssl` to `options:` and `list_options:` as shown above. Also make
+    sure to change `mysql_databases:` to `mariadb_databases:` to avoid problems with future borgmatic and MariaDB releases.
 
 This file is a minimal example for using borgmatic with an account `user` on the cloud storage provider `rsync.net` for
 a repository called `mailcow` (see `repositories` setting). This must be changed accordingly.


### PR DESCRIPTION
See:
https://community.mailcow.email/d/4365-borgmatic-backup-geht-nicht-mehr