### PR TITLE
Add restore_options to borgmatic docs

### DIFF
--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -92,6 +92,7 @@ mariadb_databases:
       password: ${DBPASS}
       options: "--default-character-set=utf8mb4 --skip-ssl"
       list_options: "--skip-ssl"
+      restore_options: "--skip-ssl"
 EOF
 ```
 
@@ -104,8 +105,8 @@ EOF
 
 !!! warning
     Ab borgmatic 1.9.4 (erschienen am 11. Dezember 2024) versuchen die enthaltenen MariaDB-Tools standardmäßig, verschlüsselte Verbindungen
-    herzustellen. Bearbeiten Sie die `config.yaml` und fügen Sie `--skip-ssl` zu `options:` und `list_options:` wie oben gezeigt hinzu.
-    Ändern Sie außerdem `mysql_databases:` in `mariadb_databases:`, um Probleme mit zukünftigen Versionen von borgmatic und MariaDB zu vermeiden.
+    herzustellen. Bearbeiten Sie die `config.yaml` und fügen Sie `--skip-ssl` zu `options`, `restore_options` und `list_options` wie oben gezeigt hinzu.
+    Ändern Sie außerdem `mysql_databases` in `mariadb_databases`, um Probleme mit zukünftigen Versionen von borgmatic und MariaDB zu vermeiden.
 
 Diese Datei ist ein minimales Beispiel für die Verwendung von borgmatic mit einem Konto `user` beim Cloud-Speicheranbieter `rsync.net` für
 ein Repository namens `mailcow` (siehe Einstellung `repositories`). Dies muss entsprechend angepasst werden.

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -93,6 +93,7 @@ mariadb_databases:
       password: ${DBPASS}
       options: "--default-character-set=utf8mb4 --skip-ssl"
       list_options: "--skip-ssl"
+      restore_options: "--skip-ssl"
 EOF
 ```
 
@@ -105,8 +106,8 @@ EOF
 
 !!! warning
     Starting with borgmatic 1.9.4 (released December 11th, 2024), the included MariaDB tools try to force encrypted connections
-    by default. Edit your `config.yaml` and add `--skip-ssl` to `options:` and `list_options:` as shown above. Also make
-    sure to change `mysql_databases:` to `mariadb_databases:` to avoid problems with future borgmatic and MariaDB releases.
+    by default. Edit your `config.yaml` and add `--skip-ssl` to `options`, `restore_options`, and `list_options` as shown above. Also make
+    sure to change `mysql_databases` to `mariadb_databases` to avoid problems with future borgmatic and MariaDB releases.
 
 This file is a minimal example for using borgmatic with an account `user` on the cloud storage provider `rsync.net` for
 a repository called `mailcow` (see `repositories` setting). This must be changed accordingly.


### PR DESCRIPTION
A few days ago, I tried to restore my borgmatic backups I made using mailcow. Unfortunately, that failed because the MariaDB client was not receiving the "-skip-ssl" argument. It seems like there is a second option for restore arguments in borgmatic called "restore_options". Therefore, I created this PR to update the borgmatic docs.