### PR TITLE
Update instructions for disabling IPv6 in nginx

### DIFF
--- a/docs/post_installation/firststeps-disable_ipv6.de.md
+++ b/docs/post_installation/firststeps-disable_ipv6.de.md
@@ -6,10 +6,10 @@ Dies wird **NUR** empfohlen, wenn Sie kein IPv6-fähiges Netzwerk auf Ihrem Host
 Wenn Sie es wirklich brauchen, können Sie die Verwendung von IPv6 in der Compose-Datei deaktivieren.
 Zusätzlich können Sie auch den Start des Containers "ipv6nat-mailcow" deaktivieren, da er nicht benötigt wird, wenn Sie IPv6 nicht verwenden.
 
-Anstatt die Datei docker-compose.yml direkt zu bearbeiten, ist es besser, eine Override-Datei zu erstellen 
+Anstatt die Datei docker-compose.yml direkt zu bearbeiten, ist es besser, eine Override-Datei zu erstellen
 zu erstellen und Ihre Änderungen am Dienst dort zu implementieren. Leider scheint dies im Moment nur für Dienste zu funktionieren, nicht für Netzwerkeinstellungen.
 
-Um IPv6 im mailcow-Netzwerk zu deaktivieren, öffnen Sie docker-compose.yml mit Ihrem bevorzugten Texteditor und suchen Sie nach dem Netzwerk-Abschnitt (er befindet sich am Ende der Datei). 
+Um IPv6 im mailcow-Netzwerk zu deaktivieren, öffnen Sie docker-compose.yml mit Ihrem bevorzugten Texteditor und suchen Sie nach dem Netzwerk-Abschnitt (er befindet sich am Ende der Datei).
 
 **1.** Ändern Sie docker-compose.yml
 
@@ -29,7 +29,7 @@ networks:
 
 **2.** ipv6nat-mailcow deaktivieren
 
-Um den ipv6nat-mailcow Container ebenfalls zu deaktivieren, gehen Sie in Ihr mailcow Verzeichnis und erstellen Sie eine neue Datei namens "docker-compose.override.yml": 
+Um den ipv6nat-mailcow Container ebenfalls zu deaktivieren, gehen Sie in Ihr mailcow Verzeichnis und erstellen Sie eine neue Datei namens "docker-compose.override.yml":
 
 **HINWEIS:** Wenn Sie bereits eine Override-Datei haben, erstellen Sie diese natürlich nicht neu, sondern fügen Sie die untenstehenden Zeilen entsprechend in Ihre bestehende Datei ein!
 
@@ -116,11 +116,27 @@ Starten Sie Postfix neu:
 
 **5.** Wenn im Docker Daemon IPv6 komplett deaktiviert ist:
 
-Folgende NGINX, Dovecot und Php-fpm Konfigurationsdateien anpassen
+Folgende Dovecot und Php-fpm Konfigurationsdateien anpassen
 
 ```
-sed -i '/::/d' data/conf/nginx/templates/listen*
-sed -i '/::/d' data/conf/nginx/dynmaps.conf
 sed -i 's/,\[::\]//g' data/conf/dovecot/dovecot.conf
 sed -i 's/\[::\]://g' data/conf/phpfpm/php-fpm.d/pools.conf
 ```
+
+**6.** IPv6 Listener für NGINX deaktivieren
+
+Setze `DISABLE_IPv6=y` in der Datei `mailcow.conf`.
+
+Damit diese Änderung wirksam wird, muss der Container `nginx-mailcow` neu erstellt werden.
+
+=== "docker compose (Plugin)"
+
+    ``` bash
+    docker compose up -d
+    ```
+
+=== "docker-compose (Standalone)"
+
+    ``` bash
+    docker-compose up -d
+    ```

--- a/docs/post_installation/firststeps-disable_ipv6.en.md
+++ b/docs/post_installation/firststeps-disable_ipv6.en.md
@@ -6,10 +6,10 @@ This is **ONLY** recommended if you do not have an IPv6 enabled network on your 
 If you really need to, you can disable the usage of IPv6 in the compose file.
 Additionally, you can  also disable the startup of container "ipv6nat-mailcow", as it's not needed if you won't use IPv6.
 
-Instead of editing docker-compose.yml directly, it is preferable to create an override file for it 
+Instead of editing docker-compose.yml directly, it is preferable to create an override file for it
 and implement your changes to the service there. Unfortunately, this right now only seems to work for services, not for network settings.
 
-To disable IPv6 on the mailcow network, open docker-compose.yml with your favourite text editor and search for the network section (it's near the bottom of the file). 
+To disable IPv6 on the mailcow network, open docker-compose.yml with your favourite text editor and search for the network section (it's near the bottom of the file).
 
 **1.** Modify docker-compose.yml
 
@@ -30,7 +30,7 @@ networks:
 
 **2.** Disable ipv6nat-mailcow
 
-To disable the ipv6nat-mailcow container as well, go to your mailcow directory and create a new file called "docker-compose.override.yml": 
+To disable the ipv6nat-mailcow container as well, go to your mailcow directory and create a new file called "docker-compose.override.yml":
 
 **NOTE:** If you already have an override file, of course don't recreate it, but merge the lines below into your existing one accordingly!
 
@@ -116,12 +116,28 @@ Restart Postfix:
 
 **5.** If your docker daemon completly disabled IPv6:
 
-Fix the following NGINX, Dovecot and php-fpm config files
+Fix the following Dovecot and php-fpm config files
 
 ```
-sed -i '/::/d' data/conf/nginx/templates/listen*
-sed -i '/::/d' data/conf/nginx/dynmaps.conf
 sed -i 's/,\[::\]//g' data/conf/dovecot/dovecot.conf
 sed -i 's/\[::\]://g' data/conf/phpfpm/php-fpm.d/pools.conf
 ```
+
+**6.** Disable IPv6 listeners for NGINX
+
+Set `DISABLE_IPv6=y` in `mailcow.conf`
+
+For this change to be effective, you need to recreate the `nginx-mailcow` Container
+
+=== "docker compose (Plugin)"
+
+    ``` bash
+    docker compose up -d
+    ```
+
+=== "docker-compose (Standalone)"
+
+    ``` bash
+    docker-compose up -d
+    ```
 


### PR DESCRIPTION
NGINX now uses jinja2 templates for config generation. 
IPv6 Listeners can now be disabled via mailcow.conf variable `DISABLE_IPv6=y`