### PR TITLE
Added necessary step to allow log rotation to be successful

### DIFF
--- a/docs/post_installation/firststeps-logging.de.md
+++ b/docs/post_installation/firststeps-logging.de.md
@@ -160,10 +160,17 @@ Erstellen Sie die Datei `/etc/logrotate.d/mailcow` mit folgendem Inhalt:
         missingok
         notifempty
         create 660 root root
+        copytruncate
+#        postrotate
+#                systemctl restart rsyslog
+#                docker compose -f /opt/mailcow-dockerized/docker-compose.yml restart postfix-mailcow
+#        endscript
 }
 ```
 
-Mit dieser Konfiguration wird logrotate täglich ausgeführt und es werden maximal 7 Archive gespeichert.
+Mit dieser Konfiguration wird logrotate täglich ausgeführt und es werden maximal 7 Archive gespeichert. Da die Log-Datei vom mailcow-Daemon permanent belegt ist, muss der Inhalt zum Rotieren mittels `copytruncate` in die neue rotierte Datei kopiert und die Log-Datei anschließend geleert werden. Dieser Schritt ist notwendig, da die Logs sonst weiterhin in die alte (bereits rotierte) Datei geschrieben werden.
+
+Alternativ zum `copytruncate` kann auch das auskommentierte `postrotate`-Snippet verwendet werden. Dafür `copytruncate` auskommentieren und die Zeilen darunter einkommentieren. So wird nach dem Rotieren der Log-Dateien der Daemon von rsyslog ([Quelle](https://www.cloudinsidr.com/content/set-up-logrotate-for-postfix/)) und der Docker-Container mit postfix-mailcow neu gestartet. Die letzten beiden Schritte sind notwendig, da die Logs sonst weiterhin in die alte (bereits rotierte) Datei geschrieben werden. Sollte ein anderer Logging-Treiber als syslog für das Logging zum Einsatz kommen, muss der Befehl (`systemctl restart rsyslog`) entsprechend abgeändert werden oder die Zeile aus obigem Beispiel entfernt werden.
 
 Um die Logdatei wöchentlich oder monatlich zu rotieren, muss `daily` durch `weekly` oder respektive `monthly` ersetzt werden.
 

--- a/docs/post_installation/firststeps-logging.en.md
+++ b/docs/post_installation/firststeps-logging.en.md
@@ -158,10 +158,17 @@ Create `/etc/logrotate.d/mailcow` with the following content:
         missingok
         notifempty
         create 660 root root
+        copytruncate
+#        postrotate
+#                systemctl restart rsyslog
+#                docker compose -f /opt/mailcow-dockerized/docker-compose.yml restart postfix-mailcow
+#        endscript
 }
 ```
 
-With this configuration, logrotate will run daily and keep a maximum of 7 archives.
+With this configuration, logrotate will run daily and keep a maximum of 7 archives. As the log file is permanently occupied by the mailcow daemon, `copytruncate` ensures that the current content of `mailcow.log` is being copied to the new rotated file and the file is being truncated afterwards. This is necessary as otherwise the logs will continue to be written to the old (already rotated) file.
+
+As an alternative to `copytruncate`, the `postrotate` snippet which is commented out by default, can be used. To do this, comment the `copytruncate` and uncomment the lines below. After rotating the log files, the rsyslog daemon ([source](https://www.cloudinsidr.com/content/set-up-logrotate-for-postfix/)) and the Docker container with postfix-mailcow are being restarted. The last two steps are necessary as otherwise the logs will continue to be written to the old (already rotated) file. If a logging driver other than syslog is used for logging, the command (`systemctl restart rsyslog`) must be modified accordingly or the line must be removed from the example above.
 
 To rotate the logfile weekly or monthly replace `daily` with `weekly` or `monthly` respectively.
 


### PR DESCRIPTION
The steps in the documentation are lacking a necessary step which ensures the content is not being written to the already rotated file after log rotation took place.

There also is an alternative shown in the snippet which lets you restart the necessary services if you won't use the `copytruncate` command.