### PR TITLE
Add documentation for AbuseIPDB Fail2Ban integration

### DIFF
--- a/docs/third_party/abuseipdb/third_party-abuseipdb.de.md
+++ b/docs/third_party/abuseipdb/third_party-abuseipdb.de.md
@@ -1,0 +1,93 @@
+# AbuseIPDB Integration für Fail2Ban
+
+## Einführung
+
+AbuseIPDB ist ein Online-Dienst, der sich auf die Erkennung und Meldung von schädlichen IP-Adressen spezialisiert hat. Er bietet eine Plattform, auf der Nutzer Informationen über verdächtige IP-Adressen sammeln und teilen können, um Cyberbedrohungen effektiver zu bekämpfen. Die Datenbank von AbuseIPDB wird kontinuierlich durch Benutzerberichte aktualisiert, was es Sicherheitsfachleuten und Netzwerkadministratoren ermöglicht, ihre Systeme proaktiv gegen potenzielle Angriffe zu schützen. Mit verschiedenen API-Integrationen und Suchfunktionen bietet AbuseIPDB eine wertvolle Ressource für die Verbesserung der Netzwerksicherheit und die Vermeidung von Missbrauch durch cyberkriminelle Aktivitäten.
+
+Über die kostenlos verwendbare AbuseIPDB API können die gelisteten IPs abgerufen und dann über die Mailcow API an Fail2Ban übergeben werden.
+
+## Vorraussetzungen
+### Erstellung eines kostenlosen Kontos bei AbuseIPDB
+
+Um die API von AbuseIPDB nutzen zu können muss ein kostenloses Konto erstellt werden: https://www.abuseipdb.com/register
+
+Nach erfolgreicher Registrierung kann man im Login Bereich über den "API" Reiter einen neuen API Key erstellen. Dieser wird für das u.g. Script benötigt.
+
+### Erstellung eines Lese-Schreib-Zugriff API Keys in Mailcow
+
+Ebenfalls für u.g. Script wird ein Lese-Schreib-Zugriff API Key für Mailcow benötigt.
+Nach Login als Admin in die Mailcow UI wird auf die Seite
+
+System -> Konfiguration
+
+gewechselt. Auf dem "Zugang" Reiter wird über das "+" Symbol neben "API" die API Übersicht aufgeklappt.
+Dort finden sich auf der rechten Seite die Einstellungen für den "Lese-Schreib-Zugriff". Hier muss die IP Adresse (ggf. IPv4 und IPv6) des Hosts eingetragen werden auf dem das u.g. später ausgeführt wird.
+Der Haken bei "API aktivieren" muss angeklickt werden und dann die Änderungen speichern.
+
+Den erzeugten API-Key sieht man dann im entsprechenden Feld.
+
+## Script
+
+Die oben gesammelten API Keys werden dann in den entsprechenden Variablen "ABUSEIP_API_KEY" und "MAILCOW_API_KEY" des folgenden Scripts verwendet. Der FQDN des eigenen Mailcow Servers wird bei "MAILSERVER_FQDN" eingetragen.
+
+```
+#!/bin/bash
+
+# Adjust the values of the following variables
+ABUSEIP_API_KEY="XXXXXXXXXXXXXXXX"
+MAILCOW_API_KEY="YYYYYYYYYYYYYYYY"
+MAILSERVER_FQDN="your.mail.server"
+
+echo "Retrieve IPs from AbuseIPDB"
+curl -sG https://api.abuseipdb.com/api/v2/blacklist \
+  -d confidenceMinimum=90 \
+  -d plaintext \
+  -H "Key: $ABUSEIP_API_KEY" \
+  -H "Accept: application/json" \
+  -o /tmp/abuseipdb_blacklist.txt
+
+# Capture the exit code from curl
+exit_code=$?
+
+# Check if curl encountered an error
+if [ $exit_code -ne 0 ]; then
+  echo "Curl encountered an error with exit code $exit_code while rertieving the AbuseIPDB IPs"
+  exit 1
+fi
+
+BLACKLIST=$(awk '{if (index($0, ":") > 0) printf "%s%s/128", sep, $0; else printf "%s%s/32", sep, $0; sep=","} END {print ""}' /tmp/abuseipdb_blacklist.txt)
+
+cat <<EOF > /tmp/request.json
+{
+  "items":["none"],
+  "attr": {
+    "blacklist": "$BLACKLIST"
+  }
+}
+EOF
+
+echo "Add IPs to Fail2Ban" 
+curl -s --include \
+     --request POST \
+     --header "Content-Type: application/json" \
+     --header "X-API-Key: $MAILCOW_API_KEY" \
+     --data-binary @/tmp/request.json \
+     "https://${MAILSERVER_FQDN}/api/v1/edit/fail2ban"
+
+# Capture the exit code from curl
+exit_code=$?
+
+# Check if curl encountered an error
+if [ $exit_code -ne 0 ]; then
+  echo "Curl encountered an error with exit code $exit_code while rertieving the AbuseIPDB IPs"
+  exit 1
+fi
+
+echo -e "\n\nAll done, have fun"
+```
+
+Das Script kann man dann via Cronjob maximal 5x am Tag laufen lassen, das ist das Limit von AbuseIPDB. In folgendem Beispiel läuft der Cronjob alle 5 Stunden: 0, 5, 10, 15 und 20 Uhr.
+
+```
+0 */5 * * * /pfad/zu/obigem/script
+```

--- a/docs/third_party/abuseipdb/third_party-abuseipdb.en.md
+++ b/docs/third_party/abuseipdb/third_party-abuseipdb.en.md
@@ -1,0 +1,89 @@
+# AbuseIPDB Integration for Fail2Ban
+
+## Introduction
+
+AbuseIPDB is an online service dedicated to the identification and reporting of malicious IP addresses. It provides a platform where users can collect and share information about suspicious IP activities, aiding in the effective combat against cyber threats. The database is constantly updated with user submissions, allowing security professionals and network administrators to proactively safeguard their systems against potential attacks. With various API integrations and search functionalities, AbuseIPDB serves as a valuable resource for enhancing network security and preventing abuse from cybercriminal activities.
+
+## Prerequisites
+### Create a free AbuseIPDB account
+
+To use the AbuseIPDB API, you must create a free account: https://www.abuseipdb.com/register
+
+After successful registration, you can create a new API key in the login area under the "API" tab. This key is required for the script below.
+
+### Creating a Read-Write Access API Key in Mailcow
+A read-write access API key for Mailcow is also needed for the script below.
+
+After logging in as an admin to the Mailcow UI, navigate to the page:
+
+System -> Configuration
+
+Switch to the "Access" tab, where you can expand the API overview using the "+" symbol next to "API". On the right side, you will find the settings for "Read-Write Access". Here, you need to enter the IP address (possibly both IPv4 and IPv6) of the host where the script will be executed later. Make sure to check the "Enable API" checkbox and then save the changes.
+
+You will then see the generated API key in the corresponding field.
+
+## Script
+
+The API keys collected above are then used in the corresponding variables "ABUSEIP_API_KEY" and "MAILCOW_API_KEY" in the following script. The FQDN of your Mailcow server should be entered in "MAILSERVER_FQDN".
+
+```
+#!/bin/bash
+
+# Adjust the values of the following variables
+ABUSEIP_API_KEY="XXXXXXXXXXXXXXXX"
+MAILCOW_API_KEY="YYYYYYYYYYYYYYYY"
+MAILSERVER_FQDN="your.mail.server"
+
+echo "Retrieve IPs from AbuseIPDB"
+curl -sG https://api.abuseipdb.com/api/v2/blacklist \
+  -d confidenceMinimum=90 \
+  -d plaintext \
+  -H "Key: $ABUSEIP_API_KEY" \
+  -H "Accept: application/json" \
+  -o /tmp/abuseipdb_blacklist.txt
+
+# Capture the exit code from curl
+exit_code=$?
+
+# Check if curl encountered an error
+if [ $exit_code -ne 0 ]; then
+  echo "Curl encountered an error with exit code $exit_code while rertieving the AbuseIPDB IPs"
+  exit 1
+fi
+
+BLACKLIST=$(awk '{if (index($0, ":") > 0) printf "%s%s/128", sep, $0; else printf "%s%s/32", sep, $0; sep=","} END {print ""}' /tmp/abuseipdb_blacklist.txt)
+
+cat <<EOF > /tmp/request.json
+{
+  "items":["none"],
+  "attr": {
+    "blacklist": "$BLACKLIST"
+  }
+}
+EOF
+
+echo "Add IPs to Fail2Ban" 
+curl -s --include \
+     --request POST \
+     --header "Content-Type: application/json" \
+     --header "X-API-Key: $MAILCOW_API_KEY" \
+     --data-binary @/tmp/request.json \
+     "https://${MAILSERVER_FQDN}/api/v1/edit/fail2ban"
+
+# Capture the exit code from curl
+exit_code=$?
+
+# Check if curl encountered an error
+if [ $exit_code -ne 0 ]; then
+  echo "Curl encountered an error with exit code $exit_code while rertieving the AbuseIPDB IPs"
+  exit 1
+fi
+
+echo -e "\n\nAll done, have fun"
+```
+
+You can run the script via a cron job up to 5 times a day, which is the limit set by AbuseIPDB. In the following example, the cron job runs every 5 hours at 0, 5, 10, 15, and 20 o'clock.
+
+```
+0 */5 * * * /path/to/the/above/script
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -202,6 +202,7 @@ nav:
     - 'Windows Mail': 'client/client-windows.md'
     - 'Manual configuration': 'client/client-manual.md'
   - 'Third party apps':
+    - 'AbuseIPDB Fail2Ban Integration': 'third_party/abuseipdb/third_party-abuseipdb.md'
     - 'Borgmatic Backup': 'third_party/borgmatic/third_party-borgmatic.md'
     - 'CheckMK' : 'third_party/checkmk/u_e-checkmk.md'
     - 'Exchange Hybrid Setup': 'third_party/exchange_onprem/third_party-exchange_onprem.md'
@@ -395,6 +396,7 @@ plugins:
         'model-sender_rcv.md': 'models/model-sender_rcv.en.md'
         'prerequisite-dns.md': 'getstarted/prerequisite-dns.en.md'
         'prerequisite-system.md': 'getstarted/prerequisite-system.en.md'
+        'third_party-abuseipdb.md': 'third_party/abuseipdb/third_party-abuseipdb.en.md'
         'third_party-borgmatic.md': 'third_party/borgmatic/third_party-borgmatic.en.md'
         'third_party-exchange_onprem.md': 'third_party/exchange_onprem/third_party-exchange_onprem.en.md'
         'third_party-gitea.md': 'third_party/gitea/third_party-gitea.en.md'


### PR DESCRIPTION
I wrote a script to add IPs, fetched from the AbuseIPDB API, to Fail2Ban as discussed in this thread:

https://community.mailcow.email/d/4527-massive-bruteforce-attacke-seit-wochen/24

I would like to add this to the Mailcow documentation for further reference :)