### PR TITLE
Add allow_admin_email_login_roundcube to admin and domainadmin mailbox views

### DIFF
--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -402,10 +402,12 @@ if (ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE) {
 }
 ```
 
-Edit `data/web/mailbox.php` and add this line to array [`$template_data`](https://github.com/mailcow/mailcow-dockerized/blob/2f9da5ae93d93bf62a8c2b7a5a6ae50a41170c48/data/web/mailbox.php#L33-L43):
+Add the following line to the array $template_data:
+* `data/web/admin/mailbox.php` [`$template_data`](https://github.com/mailcow/mailcow-dockerized/blob/master/data/web/admin/mailbox.php#L43-L56)
+* `data/web/domainadmin/mailbox.php` [`$template_data`](https://github.com/mailcow/mailcow-dockerized/blob/master/data/web/domainadmin/mailbox.php#L43-L56)
 
 ```php
-  'allow_admin_email_login_roundcube' => (preg_match("/^(yes|y)+$/i", $_ENV["ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE"])) ? 'true' : 'false',
+  'allow_admin_email_login_roundcube' => (preg_match("/^([yY][eE][sS]|[yY])+$/", $_ENV["ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE"])) ? 'true' : 'false',
 ```
 
 Edit `data/web/templates/mailbox.twig` and add this code to the bottom of the [javascript section](https://github.com/mailcow/mailcow-dockerized/blob/2f9da5ae93d93bf62a8c2b7a5a6ae50a41170c48/data/web/templates/mailbox.twig#L49-L57):


### PR DESCRIPTION
This PR introduces a new allow_admin_email_login_roundcube flag to the `$template_data` arrays in:

* `data/web/admin/mailbox.php`
* `data/web/domainadmin/mailbox.php`

The flag exposes the ALLOW_ADMIN_EMAIL_LOGIN_ROUNDCUBE environment variable to the frontend, enabling or disabling the ability for admin and domain admin users to log in via Roundcube using their email credentials.

Issue: [https://github.com/mailcow/mailcow-dockerized/issues/6476](https://github.com/mailcow/mailcow-dockerized/issues/6476)

