### PR TITLE
fixed borgmatic errors when following docs

### DIFF
--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -87,9 +87,9 @@ keep_weekly: 4
 keep_monthly: 6
 
 mariadb_databases:
-    - name: ${DBNAME}
-      username: ${DBUSER}
-      password: ${DBPASS}
+    - name: \${DBNAME}
+      username: \${DBUSER}
+      password: \${DBPASS}
       options: "--default-character-set=utf8mb4 --skip-ssl"
       list_options: "--skip-ssl"
       restore_options: "--skip-ssl"
@@ -213,8 +213,8 @@ keine benutzerdefinierten Daten in ihrem maildir oder ihrer mailcow-Datenbank ha
     SELinux wird (berechtigterweise) jeden anderen Container, wie z.B. den borgmatic Container, daran hindern, auf
     dieses Volume zu schreiben.
 
-Bevor Sie eine Wiederherstellung durchführen, müssen Sie das vmail-Volume in `docker-compose.override.yml` beschreibbar machen, indem Sie
-das `ro`-Flag aus dem Volume entfernen.
+Bevor Sie eine Wiederherstellung durchführen, müssen Sie die Volumes in `docker-compose.override.yml` beschreibbar machen, indem Sie
+das `ro`-Flag der mit `ro` eingebundenen Volumes entfernen.
 Dann können Sie den folgenden Befehl verwenden, um das Maildir aus einem Backup wiederherzustellen:
 
 === "docker compose (Plugin)"

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -88,9 +88,9 @@ keep_weekly: 4
 keep_monthly: 6
 
 mariadb_databases:
-    - name: ${DBNAME}
-      username: ${DBUSER}
-      password: ${DBPASS}
+    - name: \${DBNAME}
+      username: \${DBUSER}
+      password: \${DBPASS}
       options: "--default-character-set=utf8mb4 --skip-ssl"
       list_options: "--skip-ssl"
       restore_options: "--skip-ssl"
@@ -218,8 +218,8 @@ any custom data in your maildir or your mailcow database.
     exclusively. SELinux will (rightfully) prevent any other container, such as the borgmatic container, from writing to
     this volume.
 
-Before running a restore you must make the vmail volume writeable in `docker-compose.override.yml` by removing
-the `ro` flag from the volume.
+Before running a restore you must make the read-only volumes writeable in `docker-compose.override.yml` by removing
+the `ro` flag from the `ro` mounted volumes.
 Then you can use the following command to restore the maildir from a backup:
 
 === "docker compose (Plugin)"


### PR DESCRIPTION
Hello,

I've fixed two small problems I've encountered today when test-restoring my borgmatic backup:

1) If you only mount the vmail volume rw before restoring, there will be many errors in borgmatic.
2) when writing the YAML, the dollar signs have to be escaped. Otherwise, they are interpreted at the time of cat-ing the yaml.