### PR TITLE
Add trusted proxies to nginx setup page

### DIFF
--- a/docs/post_installation/reverse-proxy/r_p-nginx.de.md
+++ b/docs/post_installation/reverse-proxy/r_p-nginx.de.md
@@ -58,3 +58,7 @@ server {
   }
 }
 ```
+Wenn Sie einen Proxy in einem anderen Subnetz verwenden, müssen Sie der Datei mailcow.conf die folgende Umgebungsvariable hinzufügen, damit der Nginx-Container die oben festgelegte X-Real-IP akzeptiert.
+```
+TRUSTED_PROXIES=#.#.#.#
+```

--- a/docs/post_installation/reverse-proxy/r_p-nginx.en.md
+++ b/docs/post_installation/reverse-proxy/r_p-nginx.en.md
@@ -58,7 +58,7 @@ server {
   }
 }
 ```
-When using a proxy on a different subnet you will need to need to add the following environment variable to the mailcow.conf to have the nginx container accept the X-Real-IP set above.
+When using a proxy on a different subnet you will need to add the following environment variable to the mailcow.conf to have the nginx container accept the X-Real-IP set above.
 ```
 TRUSTED_PROXIES=#.#.#.#
 ```

--- a/docs/post_installation/reverse-proxy/r_p-nginx.en.md
+++ b/docs/post_installation/reverse-proxy/r_p-nginx.en.md
@@ -58,3 +58,7 @@ server {
   }
 }
 ```
+When using a proxy on a different subnet you will need to need to add the following environment variable to the mailcow.conf to have the nginx container accept the X-Real-IP set above.
+```
+TRUSTED_PROXIES=#.#.#.#
+```


### PR DESCRIPTION
Added note about TRUSTED_PROXIES that seems to have been added in the last release.
Apologies if is the German translation is poor, it is not my native language and I google translated it.