### PR TITLE
Drop rsync.net in favor of another provider

### DIFF
--- a/docs/third_party/borgmatic/third_party-borgmatic.de.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.de.md
@@ -74,7 +74,7 @@ source_directories:
     - /mnt/source/rspamd
     - /mnt/source/postfix
 repositories:
-    - path: ssh://user@rsync.net:22/./mailcow
+    - path: ssh://uXXXXX@uXXXXX.your-storagebox.de:23/./mailcow
       label: rsync
 exclude_patterns:
     - '/mnt/source/postfix/public/'
@@ -108,8 +108,7 @@ EOF
     herzustellen. Bearbeiten Sie die `config.yaml` und fügen Sie `--skip-ssl` zu `options`, `restore_options` und `list_options` wie oben gezeigt hinzu.
     Ändern Sie außerdem `mysql_databases` in `mariadb_databases`, um Probleme mit zukünftigen Versionen von borgmatic und MariaDB zu vermeiden.
 
-Diese Datei ist ein minimales Beispiel für die Verwendung von borgmatic mit einem Konto `user` beim Cloud-Speicheranbieter `rsync.net` für
-ein Repository namens `mailcow` (siehe Einstellung `repositories`). Dies muss entsprechend angepasst werden.
+Diese Datei ist ein minimales Beispiel für die Verwendung von borgmatic mit einem Konto `uXXXXX` auf einer Storage Box beim Cloud-Speicheranbieter `Hetzner`. Als Repository wird `mailcow` verwendet (siehe Einstellung `repositories`). Dies muss entsprechend angepasst werden.
 
 Es wird sowohl das maildir als auch die MySQL-Datenbank gesichert, was alles ist, was Sie brauchen, um Ihre mailcow nach einem Vorfall wiederherzustellen.
 
@@ -339,13 +338,13 @@ Um das `keyfile` zu holen, führen Sie aus:
 === "docker compose (Plugin)"
 
     ``` bash
-    docker compose exec borgmatic-mailcow borg key export --paper user@rsync.net:mailcow
+    docker compose exec -e BORG_RSH="ssh -p 23" borgmatic-mailcow borg key export --paper uXXXXX@uXXXXX.your-storagebox.de:mailcow
     ```
 
 === "docker-compose (Standalone)"
 
     ``` bash
-    docker-compose exec borgmatic-mailcow borg key export --paper user@rsync.net:mailcow
+    docker-compose exec -e BORG_RSH="ssh -p 23" borgmatic-mailcow borg key export --paper uXXXXX@uXXXXX.your-storagebox.de:mailcow
     ```
 
-Wobei `user@rsync.net:mailcow` die URI zu Ihrem Repository ist.
+Wobei `uXXXXX@uXXXXX.your-storagebox.de:mailcow` die URI zu Ihrem Repository ist.

--- a/docs/third_party/borgmatic/third_party-borgmatic.en.md
+++ b/docs/third_party/borgmatic/third_party-borgmatic.en.md
@@ -75,7 +75,7 @@ source_directories:
     - /mnt/source/rspamd
     - /mnt/source/postfix
 repositories:
-    - path: ssh://user@rsync.net:22/./mailcow
+    - path: ssh://uXXXXX@uXXXXX.your-storagebox.de:23/./mailcow
       label: rsync
 exclude_patterns:
     - '/mnt/source/postfix/public/'
@@ -109,8 +109,7 @@ EOF
     by default. Edit your `config.yaml` and add `--skip-ssl` to `options`, `restore_options`, and `list_options` as shown above. Also make
     sure to change `mysql_databases` to `mariadb_databases` to avoid problems with future borgmatic and MariaDB releases.
 
-This file is a minimal example for using borgmatic with an account `user` on the cloud storage provider `rsync.net` for
-a repository called `mailcow` (see `repositories` setting). This must be changed accordingly.
+This file is a minimal example for using borgmatic with an account `uXXXXX` on a Storage Box from the cloud storage provider `Hetzner`. The repository is called `mailcow` (see `repositories` setting). This must be changed accordingly.
 
 It will backup both the maildir and MySQL database, which is
 all you should need to restore your mailcow setup after an incident.
@@ -345,13 +344,13 @@ To fetch the keyfile run:
 === "docker compose (Plugin)"
 
     ``` bash
-    docker compose exec borgmatic-mailcow borg key export --paper user@rsync.net:mailcow
+    docker compose exec -e BORG_RSH="ssh -p 23" borgmatic-mailcow borg key export --paper uXXXXX@uXXXXX.your-storagebox.de:mailcow
     ```
 
 === "docker-compose (Standalone)"
 
     ``` bash
-    docker-compose exec borgmatic-mailcow borg key export --paper user@rsync.net:mailcow
+    docker-compose exec -e BORG_RSH="ssh -p 23" borgmatic-mailcow borg key export --paper uXXXXX@uXXXXX.your-storagebox.de:mailcow
     ```
 
-Where `user@rsync.net:mailcow` is the URI to your repository.
+Where `uXXXXX@uXXXXX.your-storagebox.de:mailcow` is the URI to your repository.


### PR DESCRIPTION
rsync.net won't work anymore with `docker-borgmatic` from May 16th

rsync.net informed me that:
> In addition, a v1.4 'borg' binary will be made available and can be reached by specifically calling '--remote-path=borg14'.  This means the list of 'borg' binaries that may be called is:
> 
> --remote-path=borg0     (borg v0.29) - available now
> --remote-path=borg12    (1.2.x branch - available now
> --remote-path=borg14    (1.4.x branch) - available after update
> 
> ... and we will be removing the plain old 'borg' binary which means you MUST explicitly specify a borg version using one of the three binaries above.  THIS MEANS that if you don't have a --remote-path argument in your borg command it will begin to fail on May 1 2025.

They have extended the deadline from 1st of May to May 16th.

Hetzner is a good alternative that can be pointed to in the docs. I already moved from rsync.net to Hetzner and the borgmatic backup is working well with Hetzner.

Further information can be found here:
https://docs.hetzner.com/de/storage/storage-box/backup-space-ssh-keys/
https://docs.hetzner.com/de/storage/storage-box/access/access-ssh-rsync-borg/