### PR TITLE
Add more SecuriteInfo database and remove spam_marketing from the list

### DIFF
--- a/docs/manual-guides/ClamAV/u_e-clamav-additional_dbs.de.md
+++ b/docs/manual-guides/ClamAV/u_e-clamav-additional_dbs.de.md
@@ -20,11 +20,20 @@ Die Standard ClamAV Datenbanken haben keine hohe Trefferquote, können aber durc
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.hdb
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.ign2
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/javascript.ndb
-DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/spam_marketing.ndb
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfohtml.hdb
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfoascii.hdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfoandroid.hdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfoold.hdb
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfopdf.hdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo0hour.hdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.mdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.yara
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.pdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.wdb
 ```
+
+!!! danger
+    Die SecuriteInfo-Datenbank spam_marketing.ndb weist bekanntermaßen erhebliche falsch-positive Regeln auf. Sie gehen damit Ihr eigenes Risiko ein!
 
 8. Bei den kostenlosen SecuriteInfo Datenbanken ist die Download-Geschwindigkeit auf 300 kB/s begrenzt. Ändern Sie in `data/conf/clamav/freshclam.conf` den Standardwert `ReceiveTimeout 20` auf `ReceiveTimeout 90` (Zeitangabe in Sekunden), da ansonsten einige der Datenbank-Downloads aufgrund ihrer Größe abbrechen können.
 

--- a/docs/manual-guides/ClamAV/u_e-clamav-additional_dbs.en.md
+++ b/docs/manual-guides/ClamAV/u_e-clamav-additional_dbs.en.md
@@ -21,11 +21,20 @@ Default ClamAV databases do not have great detection levels, but it can be enhan
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.hdb
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.ign2
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/javascript.ndb
-DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/spam_marketing.ndb
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfohtml.hdb
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfoascii.hdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfoandroid.hdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfoold.hdb
 DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfopdf.hdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo0hour.hdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.mdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.yara
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.pdb
+DatabaseCustomURL https://www.securiteinfo.com/get/signatures/your_id/securiteinfo.wdb
 ```
+
+!!! danger
+    SecuriteInfo spam_marketing.ndb database is known to have significant false positive rules, add on your own risk!
 
 8. For free SecuriteInfo databases, download speed is limited to 300 kB/s. In `data/conf/clamav/freshclam.conf`, increase the default `ReceiveTimeout 20` value to `ReceiveTimeout 90` (time in seconds), otherwise some of the database downloads could fail because of their size.
 


### PR DESCRIPTION
Actualize up-to-date list of useful SecuriteInfo, remove spam_marketing.ndb from the list and add warning about significant FPs from spam_marketing.ndb so it can be used only if user sure so.