### PR TITLE
add network_mode for ipv6nat disabling

### DIFF
--- a/docs/post_installation/firststeps-disable_ipv6.de.md
+++ b/docs/post_installation/firststeps-disable_ipv6.de.md
@@ -47,6 +47,7 @@ services:
       image: bash:latest
       restart: "no"
       entrypoint: ["echo", "ipv6nat disabled in compose.override.yml"]
+      network_mode: "host"
 ```
 
 Damit diese Änderungen wirksam werden, müssen Sie den Stack vollständig stoppen und dann neu starten, damit Container und Netzwerke neu erstellt werden:

--- a/docs/post_installation/firststeps-disable_ipv6.en.md
+++ b/docs/post_installation/firststeps-disable_ipv6.en.md
@@ -48,6 +48,7 @@ services:
       image: bash:latest
       restart: "no"
       entrypoint: ["echo", "ipv6nat disabled in compose.override.yml"]
+      network_mode: "host"
 ```
 
 For these changes to be effective, you need to fully stop and then restart the stack, so containers and networks are recreated:


### PR DESCRIPTION
yes. probably soon obsolete.
nontheless: if there is no network_mode, docker creates a bridge network "<foldername>_default" just for this part.
"host" is save, since it exists usually.