### PR TITLE
Fix links to rspamd documentation

### DIFF
--- a/docs/manual-guides/Rspamd/u_e-rspamd-general.de.md
+++ b/docs/manual-guides/Rspamd/u_e-rspamd-general.de.md
@@ -1,4 +1,4 @@
-Rspamd wird für die AV-Verarbeitung, DKIM-Signierung und SPAM-Verarbeitung verwendet. Es ist ein leistungsfähiges und schnelles Filtersystem. Für eine ausführlichere Dokumentation über Rspamd besuchen Sie bitte die [Rspamd Dokumentation] (https://rspamd.com/doc/index.html).
+Rspamd wird für die AV-Verarbeitung, DKIM-Signierung und SPAM-Verarbeitung verwendet. Es ist ein leistungsfähiges und schnelles Filtersystem. Für eine ausführlichere Dokumentation über Rspamd besuchen Sie bitte die [Rspamd Dokumentation] (https://docs.rspamd.com/).
 
 ## UI Zugang
 
@@ -15,7 +15,7 @@ Dies tun Sie wie folgt:
 3. Ändern Sie hier das Rspamd UI Passwort, bzw. legen Sie eines fest.
 4. Gehen Sie in einem Browser zu https://${MAILCOW_HOSTNAME}/rspamd und melden Sie sich an!
 
-Weitere Konfigurationsoptionen und Dokumentation zur WebUI finden Sie hier: https://rspamd.com/webui/
+Weitere Konfigurationsoptionen und Dokumentation zur WebUI finden Sie hier: https://docs.rspamd.com/
 
 ---
 

--- a/docs/manual-guides/Rspamd/u_e-rspamd-general.en.md
+++ b/docs/manual-guides/Rspamd/u_e-rspamd-general.en.md
@@ -1,4 +1,4 @@
-Rspamd is used for AV handling, DKIM signing and SPAM handling. It's a powerful and fast filter system. For a more in-depth documentation on Rspamd please visit its [own documentation](https://rspamd.com/doc/index.html).
+Rspamd is used for AV handling, DKIM signing and SPAM handling. It's a powerful and fast filter system. For a more in-depth documentation on Rspamd please visit its [own documentation](https://docs.rspamd.com/).
 
 ## UI access
 
@@ -15,7 +15,7 @@ You do this as follows:
 3. Change the Rspamd UI password here, or set one.
 4. Go to https://${MAILCOW_HOSTNAME}/rspamd in a browser and log in!
 
-Further configuration options and documentation for the WebUI can be found here: https://rspamd.com/webui/
+Further configuration options and documentation for the WebUI can be found here: https://docs.rspamd.com/
 
 ---
 


### PR DESCRIPTION
While checking the docs about rspamd I noticed the links no longer work.

Seems like they migrated their docs to a new domain and restructured it too.

Not sure if the second link that used to go the webui docs is ideal but I did not find any specific page about the webui itself.
