### PR TITLE
fixed Markdown Alerts

### DIFF
--- a/docs/post_installation/reverse-proxy/r_p-traefik3.de.md
+++ b/docs/post_installation/reverse-proxy/r_p-traefik3.de.md
@@ -1,8 +1,8 @@
 !!! warning "Wichtig"
-Lesen Sie zuerst [die Übersicht](r_p.md).
+    Lesen Sie zuerst [die Übersicht](r_p.md).
 
 !!! danger "Vorsicht"
-Dies ist ein von der Community unterstützter Beitrag. Korrekturen sind willkommen.
+    Dies ist ein von der Community unterstützter Beitrag. Korrekturen sind willkommen.
 
 Dieses Tutorial erklärt, wie man mailcow mit Traefik als Reverse-Proxy einrichtet, um HTTPS-Verbindungen, Domain-Routing und Zertifikatsmanagement zu handhaben.
 

--- a/docs/post_installation/reverse-proxy/r_p-traefik3.en.md
+++ b/docs/post_installation/reverse-proxy/r_p-traefik3.en.md
@@ -1,8 +1,8 @@
 !!! warning "Important"
-First read [the overview](r_p.md).
+    First read [the overview](r_p.md).
 
 !!! danger
-This is an community supported contribution. Feel free to provide fixes.
+    This is an community supported contribution. Feel free to provide fixes.
 
 This tutorial explains how to set up mailcow with Traefik as a reverse proxy to handle HTTPS connections, domain routing, and certificate management.
 

--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -1,11 +1,11 @@
 ## Installation von Roundcube
 
 !!! note "Beachten Sie"
-Sofern nicht abweichend angegeben wird für alle aufgeführten Kommandos angenommen, dass diese im mailcow
-Installationsverzeichnis ausgeführt werden, d. h. dem Verzeichnis, welches `mailcow.conf` usw. enthält. Bitte führen Sie
-die Kommandos nicht blind aus, sondern verstehen Sie was diese bewirken. Keines der Kommandos sollte einen Fehler
-ausgeben; sollten Sie dennoch auf einen Fehler stoßen, beheben Sie diesen sofern notwendig bevor Sie mit den
-nachfolgenden Kommandos fortfahren.
+    Sofern nicht abweichend angegeben wird für alle aufgeführten Kommandos angenommen, dass diese im mailcow
+    Installationsverzeichnis ausgeführt werden, d. h. dem Verzeichnis, welches `mailcow.conf` usw. enthält. Bitte führen Sie
+    die Kommandos nicht blind aus, sondern verstehen Sie was diese bewirken. Keines der Kommandos sollte einen Fehler
+    ausgeben; sollten Sie dennoch auf einen Fehler stoßen, beheben Sie diesen sofern notwendig bevor Sie mit den
+    nachfolgenden Kommandos fortfahren.
 
 ## Integrierte Installation
 
@@ -347,9 +347,9 @@ Falls ein Plugin noch nicht vorinstalliert, bzw. installiert ist muss dieses auc
 **Wichtige Information für den Verlauf der Dokumentation:**
 
 !!! note
-Im Verlauf der Dokumentation werden Sie gebeten Dateien innerhalb von `data/web/rc/config` zu verändern
-nutzen Sie stattdessen `data/web/rc/persistent-config` oder `data/rc/config` (Erweiterte Variante).
-Dies liegt daran, dass Roundcube seine Konfigurationsdateien automatisch anhand von Konfigurationsdateien in `persistent-config/` / `data/rc/config/` innerhalb von `rc/main/config/` oder `web/rc/config/` erstellt.
+    Im Verlauf der Dokumentation werden Sie gebeten Dateien innerhalb von `data/web/rc/config` zu verändern
+    nutzen Sie stattdessen `data/web/rc/persistent-config` oder `data/rc/config` (Erweiterte Variante).
+    Dies liegt daran, dass Roundcube seine Konfigurationsdateien automatisch anhand von Konfigurationsdateien in `persistent-config/` / `data/rc/config/` innerhalb von `rc/main/config/` oder `web/rc/config/` erstellt.
 
 If you chose to mount in the _Advanced_ way notice folders like `plugins/` are located inside of `data/rc/main`.
 Sofern Sie sich für die Erweiterte Variante entschieden haben merken Sie sich, dass Ordner wie `plugins/` sich in `data/rc/main` befinden.

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -1,10 +1,10 @@
 ## Installing Roundcube
 
 !!! note
-Unless otherwise stated, all of the given commands are expected to be executed in the mailcow installation directory,
-i.e., the directory containing `mailcow.conf` etc. Please do not blindly execute the commands but understand what they
-do. None of the commands is supposed to produce an error, so if you encounter an error, fix it if necessary before
-continuing with the subsequent commands.
+    Unless otherwise stated, all of the given commands are expected to be executed in the mailcow installation directory,
+    i.e., the directory containing `mailcow.conf` etc. Please do not blindly execute the commands but understand what they
+    do. None of the commands is supposed to produce an error, so if you encounter an error, fix it if necessary before
+    continuing with the subsequent commands.
 
 ## Integrated Install
 
@@ -337,8 +337,8 @@ After all of the steps above you can start the Roundcube Container with.
 **Important notes about this configuration:**
 
 !!! note
-For the rest of this Documentation you will be asked to modify files inside of `data/web/rc/config` use `data/web/rc/persistent-config` or `data/rc/config` (Advanced) instead.
-This is due to Roundcube auto-generating configs inside of `rc/main/config/` or `web/rc/config/` based on configs in `persistent-config/` / `data/rc/config/`.
+    For the rest of this Documentation you will be asked to modify files inside of `data/web/rc/config` use `data/web/rc/persistent-config` or `data/rc/config` (Advanced) instead.
+    This is due to Roundcube auto-generating configs inside of `rc/main/config/` or `web/rc/config/` based on configs in `persistent-config/` / `data/rc/config/`.
 
 If you chose to mount in the _Advanced_ way notice folders like `plugins/` are located inside of `data/rc/main`.
 


### PR DESCRIPTION
- added missing indentation for mkdocs

These were removed by Prettier in previous commits authored by @CodeShellDev 