### PR TITLE
fixed Roundcube Standalone Documentation (after further testing)

### DIFF
--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -1,11 +1,11 @@
 ## Installation von Roundcube
 
 !!! note "Beachten Sie"
-    Sofern nicht abweichend angegeben wird für alle aufgeführten Kommandos angenommen, dass diese im mailcow
-    Installationsverzeichnis ausgeführt werden, d. h. dem Verzeichnis, welches `mailcow.conf` usw. enthält. Bitte führen Sie
-    die Kommandos nicht blind aus, sondern verstehen Sie was diese bewirken. Keines der Kommandos sollte einen Fehler
-    ausgeben; sollten Sie dennoch auf einen Fehler stoßen, beheben Sie diesen sofern notwendig bevor Sie mit den
-    nachfolgenden Kommandos fortfahren.
+Sofern nicht abweichend angegeben wird für alle aufgeführten Kommandos angenommen, dass diese im mailcow
+Installationsverzeichnis ausgeführt werden, d. h. dem Verzeichnis, welches `mailcow.conf` usw. enthält. Bitte führen Sie
+die Kommandos nicht blind aus, sondern verstehen Sie was diese bewirken. Keines der Kommandos sollte einen Fehler
+ausgeben; sollten Sie dennoch auf einen Fehler stoßen, beheben Sie diesen sofern notwendig bevor Sie mit den
+nachfolgenden Kommandos fortfahren.
 
 ## Integrierte Installation
 
@@ -311,7 +311,7 @@ location /rc/ {
 EOCONFIG
 ```
 
-### Anlegen der Roundcube-Datenbank
+### Anlegen der Roundcube-Datenbank Passwörter
 
 Zunächst falls noch nicht getan, die Shell Variablen laden:
 
@@ -352,9 +352,9 @@ Falls ein Plugin noch nicht vorinstalliert, bzw. installiert ist muss dieses auc
 **Wichtige Information für den Verlauf der Dokumentation:**
 
 !!! note
-    Im Verlauf der Dokumentation werden Sie gebeten Dateien innerhalb von `data/web/rc/config` zu verändern
-    nutzen Sie stattdessen `data/web/rc/persistent-config` oder `data/rc/config` (Erweiterte Variante).
-    Dies liegt daran, dass Roundcube seine Konfigurationsdateien automatisch anhand von Konfigurationsdateien in `persistent-config/` / `data/rc/config/` innerhalb von `rc/main/config/` oder `web/rc/config/` erstellt.
+Im Verlauf der Dokumentation werden Sie gebeten Dateien innerhalb von `data/web/rc/config` zu verändern
+nutzen Sie stattdessen `data/web/rc/persistent-config` oder `data/rc/config` (Erweiterte Variante).
+Dies liegt daran, dass Roundcube seine Konfigurationsdateien automatisch anhand von Konfigurationsdateien in `persistent-config/` / `data/rc/config/` innerhalb von `rc/main/config/` oder `web/rc/config/` erstellt.
 
 If you chose to mount in the _Advanced_ way notice folders like `plugins/` are located inside of `data/rc/main`.
 Sofern Sie sich für die Erweiterte Variante entschieden haben merken Sie sich, dass Ordner wie `plugins/` sich in `data/rc/main` befinden.
@@ -421,15 +421,15 @@ EOCONFIG
 ## CardDAV-Adressbücher in Roundcube einbinden
 
 === "Integriert"
-    Installieren Sie die neuste v5-Version (die untenstehende Konfiguration ist kompatibel zu v5-Releases) mit composer.
-    Antworten Sie `Y`, wenn Sie gefragt werden, ob Sie das Plugin aktivieren möchten.
+Installieren Sie die neuste v5-Version (die untenstehende Konfiguration ist kompatibel zu v5-Releases) mit composer.
+Antworten Sie `Y`, wenn Sie gefragt werden, ob Sie das Plugin aktivieren möchten.
 
     ```bash
     docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer require --update-no-dev -o "roundcube/carddav:~5"
     ```
 
 === "Extern"
-    Installieren Sie die neueste version von CardDAV indem Sie `carddav` zu `ROUNDCUBEMAIL_PLUGINS` hinzufügen:
+Installieren Sie die neueste version von CardDAV indem Sie `carddav` zu `ROUNDCUBEMAIL_PLUGINS` hinzufügen:
 
     ```yaml
     ROUNDCUBEMAIL_PLUGINS: archive, managesieve, acl, markasjunk, zipdownload, carddav
@@ -550,7 +550,7 @@ Installieren Sie zunächst das Plugin [dovecot_impersonate](https://github.com/c
     docker exec -it -w /var/www/html/plugins $(docker ps -f name=roundcube -q) git clone https://github.com/corbosman/dovecot_impersonate.git
     ```
 
-Editieren Sie `data/web/rc/config/config.inc.php` und aktivieren Sie das dovecot_impersonate Plugin indem Sie es zum Array `$config['plugins']` 
+Editieren Sie `data/web/rc/config/config.inc.php` und aktivieren Sie das dovecot_impersonate Plugin indem Sie es zum Array `$config['plugins']`
 oder zur `ROUNDCUBEMAIL_PLUGINS` Variable hinzufügen,
 zum Beispiel:
 
@@ -684,7 +684,7 @@ Starten Sie schließlich mailcow neu
     ```
 
 === "Extern"
-    Ein Upgrade von Roundcube ist in der Externen Installation ziemlich einfach, es muss lediglich der Version-Tag heraufgestuft werden:
+Ein Upgrade von Roundcube ist in der Externen Installation ziemlich einfach, es muss lediglich der Version-Tag heraufgestuft werden:
 
     ```yaml
     image: roundcube/roundcubemail:1.6.11-apache # 1.6.11 -> 1.6.X (in der Zukunft: 1.7.X)
@@ -706,7 +706,7 @@ Starten Sie schließlich mailcow neu
 === "Extern"
 
     Um Roundcube-Plugins zu aktualisieren müssen lediglich die Version-Tags zur neusten Version erhöht werden:
-    
+
     ```yaml
           ROUNDCUBEMAIL_COMPOSER_PLUGINS: "roundcube/carddav:~4" # zu v5 erhöhen
     ```
@@ -911,5 +911,3 @@ entfernen:
 ```bash
 docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -sN mailcow -e "SET SESSION foreign_key_checks = 0; DROP TABLE IF EXISTS $(echo $RCTABLES | sed -e 's/ \+/,/g');"
 ```
-
-

--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -1,11 +1,11 @@
 ## Installation von Roundcube
 
 !!! note "Beachten Sie"
-Sofern nicht abweichend angegeben wird für alle aufgeführten Kommandos angenommen, dass diese im mailcow
-Installationsverzeichnis ausgeführt werden, d. h. dem Verzeichnis, welches `mailcow.conf` usw. enthält. Bitte führen Sie
-die Kommandos nicht blind aus, sondern verstehen Sie was diese bewirken. Keines der Kommandos sollte einen Fehler
-ausgeben; sollten Sie dennoch auf einen Fehler stoßen, beheben Sie diesen sofern notwendig bevor Sie mit den
-nachfolgenden Kommandos fortfahren.
+    Sofern nicht abweichend angegeben wird für alle aufgeführten Kommandos angenommen, dass diese im mailcow
+    Installationsverzeichnis ausgeführt werden, d. h. dem Verzeichnis, welches `mailcow.conf` usw. enthält. Bitte führen Sie
+    die Kommandos nicht blind aus, sondern verstehen Sie was diese bewirken. Keines der Kommandos sollte einen Fehler
+    ausgeben; sollten Sie dennoch auf einen Fehler stoßen, beheben Sie diesen sofern notwendig bevor Sie mit den
+    nachfolgenden Kommandos fortfahren.
 
 ## Integrierte Installation
 
@@ -352,9 +352,9 @@ Falls ein Plugin noch nicht vorinstalliert, bzw. installiert ist muss dieses auc
 **Wichtige Information für den Verlauf der Dokumentation:**
 
 !!! note
-Im Verlauf der Dokumentation werden Sie gebeten Dateien innerhalb von `data/web/rc/config` zu verändern
-nutzen Sie stattdessen `data/web/rc/persistent-config` oder `data/rc/config` (Erweiterte Variante).
-Dies liegt daran, dass Roundcube seine Konfigurationsdateien automatisch anhand von Konfigurationsdateien in `persistent-config/` / `data/rc/config/` innerhalb von `rc/main/config/` oder `web/rc/config/` erstellt.
+    Im Verlauf der Dokumentation werden Sie gebeten Dateien innerhalb von `data/web/rc/config` zu verändern
+    nutzen Sie stattdessen `data/web/rc/persistent-config` oder `data/rc/config` (Erweiterte Variante).
+    Dies liegt daran, dass Roundcube seine Konfigurationsdateien automatisch anhand von Konfigurationsdateien in `persistent-config/` / `data/rc/config/` innerhalb von `rc/main/config/` oder `web/rc/config/` erstellt.
 
 If you chose to mount in the _Advanced_ way notice folders like `plugins/` are located inside of `data/rc/main`.
 Sofern Sie sich für die Erweiterte Variante entschieden haben merken Sie sich, dass Ordner wie `plugins/` sich in `data/rc/main` befinden.
@@ -421,15 +421,15 @@ EOCONFIG
 ## CardDAV-Adressbücher in Roundcube einbinden
 
 === "Integriert"
-Installieren Sie die neuste v5-Version (die untenstehende Konfiguration ist kompatibel zu v5-Releases) mit composer.
-Antworten Sie `Y`, wenn Sie gefragt werden, ob Sie das Plugin aktivieren möchten.
+    Installieren Sie die neuste v5-Version (die untenstehende Konfiguration ist kompatibel zu v5-Releases) mit composer.
+    Antworten Sie `Y`, wenn Sie gefragt werden, ob Sie das Plugin aktivieren möchten.
 
     ```bash
     docker exec -it -w /web/rc $(docker ps -f name=php-fpm-mailcow -q) composer require --update-no-dev -o "roundcube/carddav:~5"
     ```
 
 === "Extern"
-Installieren Sie die neueste version von CardDAV indem Sie `carddav` zu `ROUNDCUBEMAIL_PLUGINS` hinzufügen:
+    Installieren Sie die neueste version von CardDAV indem Sie `carddav` zu `ROUNDCUBEMAIL_PLUGINS` hinzufügen:
 
     ```yaml
     ROUNDCUBEMAIL_PLUGINS: archive, managesieve, acl, markasjunk, zipdownload, carddav
@@ -550,7 +550,7 @@ Installieren Sie zunächst das Plugin [dovecot_impersonate](https://github.com/c
     docker exec -it -w /var/www/html/plugins $(docker ps -f name=roundcube -q) git clone https://github.com/corbosman/dovecot_impersonate.git
     ```
 
-Editieren Sie `data/web/rc/config/config.inc.php` und aktivieren Sie das dovecot_impersonate Plugin indem Sie es zum Array `$config['plugins']`
+Editieren Sie `data/web/rc/config/config.inc.php` und aktivieren Sie das dovecot_impersonate Plugin indem Sie es zum Array `$config['plugins']` 
 oder zur `ROUNDCUBEMAIL_PLUGINS` Variable hinzufügen,
 zum Beispiel:
 
@@ -684,7 +684,7 @@ Starten Sie schließlich mailcow neu
     ```
 
 === "Extern"
-Ein Upgrade von Roundcube ist in der Externen Installation ziemlich einfach, es muss lediglich der Version-Tag heraufgestuft werden:
+    Ein Upgrade von Roundcube ist in der Externen Installation ziemlich einfach, es muss lediglich der Version-Tag heraufgestuft werden:
 
     ```yaml
     image: roundcube/roundcubemail:1.6.11-apache # 1.6.11 -> 1.6.X (in der Zukunft: 1.7.X)
@@ -706,7 +706,7 @@ Ein Upgrade von Roundcube ist in der Externen Installation ziemlich einfach, es 
 === "Extern"
 
     Um Roundcube-Plugins zu aktualisieren müssen lediglich die Version-Tags zur neusten Version erhöht werden:
-
+    
     ```yaml
           ROUNDCUBEMAIL_COMPOSER_PLUGINS: "roundcube/carddav:~4" # zu v5 erhöhen
     ```
@@ -911,3 +911,5 @@ entfernen:
 ```bash
 docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -sN mailcow -e "SET SESSION foreign_key_checks = 0; DROP TABLE IF EXISTS $(echo $RCTABLES | sed -e 's/ \+/,/g');"
 ```
+
+

--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -241,7 +241,21 @@ Um Roundcube in einem eigenen Docker-Container installieren zu können muss zu I
 
 ```yaml
 services:
-  # ...
+  roundcube-db:
+    image: mariadb:10.11
+    volumes:
+      - roundcube-db:/var/lib/mysql/
+    environment:
+      TZ: ${TZ}
+      MYSQL_ROOT_PASSWORD: ${DBROUNDCUBEROOT}
+      MYSQL_DATABASE: roundcubemail
+      MYSQL_USER: roundcube
+      MYSQL_PASSWORD: ${DBROUNDCUBE}
+    restart: unless-stopped
+    networks:
+      mailcow-network:
+        aliases:
+          - roundcube-db
 
   roundcube:
     image: roundcube/roundcubemail:1.6.11-apache # Siehe neuste version https://hub.docker.com/r/roundcube/roundcubemail/tags?name=apache
@@ -249,7 +263,7 @@ services:
       IPV4_NETWORK: ${IPV4_NETWORK:-172.22.1}
       IPV6_NETWORK: ${IPV6_NETWORK:-fd4d:6169:6c63:6f77::/64}
       ROUNDCUBEMAIL_DB_TYPE: mysql
-      ROUNDCUBEMAIL_DB_HOST: mysql
+      ROUNDCUBEMAIL_DB_HOST: roundcube-db
       ROUNDCUBEMAIL_DB_USER: roundcube
       ROUNDCUBEMAIL_DB_PASSWORD: ${DBROUNDCUBE}
       ROUNDCUBEMAIL_DB_NAME: roundcubemail
@@ -267,7 +281,7 @@ services:
       - ./data/rc/main:/var/www/html
       - ./data/rc/config:/var/roundcube/config
     depends_on:
-      - mysql-mailcow
+      - roundcube-db
       - dovecot-mailcow
     restart: unless-stopped
     networks:
@@ -275,9 +289,8 @@ services:
         aliases:
           - roundcube
 
-networks:
-  proxy:
-    external: true
+volumes:
+  roundcube-db:
 ```
 
 ### Webserver-Konfiguration
@@ -288,7 +301,12 @@ daher eine Konfigurations-Ergänzung für nginx, um nur die öffentlichen Teile 
 ```bash
 cat <<EOCONFIG >data/conf/nginx/site.roundcube.custom
 location /rc/ {
-  alias /web/rc/public_html/;
+    proxy_pass http://roundcube:80/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_redirect off;
 }
 EOCONFIG
 ```
@@ -301,27 +319,14 @@ Zunächst falls noch nicht getan, die Shell Variablen laden:
 source mailcow.conf
 ```
 
-Erstellen Sie eine Datenbank für Roundcube im mailcow mysql Container. Dies erstellt einen neuen `roundcube`
-Datenbank-Benutzer mit einem Zufallspasswort, welches in die Shell ausgegeben wird und in einer Shell-Variable für die
-Verwendung durch die nachfolgenden Kommandos gespeichert wird. Beachten Sie, dass Sie die `DBROUNDCUBE`-Shell-Variable
-manuell auf das ausgegebene Passwort setzen müssen, falls sie den Installationsprozess unterbrechen und später in einer
-neuen Shell fortsetzen sollten.
+Erstellen Sie eine Datenbank für Roundcube im Roundcube mysql Container. Dies erstellt einen neuen `roundcube`
+Datenbank-Benutzer mit einem Zufallspasswort, welches in die Shell ausgegeben wird.
 
-Hiermit besagtes Passwort generieren:
+Generieren Sie ein Passwort für jeweils `DBROUNDCUBEROOT` und `DBROUNDCUBE` und setzen Sie diese in der `mailcow.conf` Datei.
 
 ```bash
 LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28
 ```
-
-Anschließend den Wert `DBROUNDCUBE` in der Datei mailcow.conf auf das generierte Passwort setzen und...
-
-```bash
-docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "CREATE DATABASE roundcubemail CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "CREATE USER 'roundcube'@'%' IDENTIFIED BY '${DBROUNDCUBE}';"
-docker exec -it $(docker ps -f name=mysql-mailcow -q) mysql -uroot -p${DBROOT} -e "GRANT ALL PRIVILEGES ON roundcubemail.* TO 'roundcube'@'%';"
-```
-
-ausführen.
 
 ### Optional: Plugins hinzufügen
 


### PR DESCRIPTION
- added seperate db for Roundcube -> solves previous db issues
- changed `Standalone Installation` in `en` from `###` to `##`
- removed unneeded networks from `de` in the compose file
- replaced incorrect `site.roundcube.custom` nginx config file

These changes where tested and fixed previous db init errors.