### PR TITLE
Enhance Nginx reverse proxy configurations for HTTP/3 and SOGo

### DIFF
--- a/docs/manual-guides/Nginx/u_e-nginx_custom.de.md
+++ b/docs/manual-guides/Nginx/u_e-nginx_custom.de.md
@@ -86,7 +86,7 @@ server {
 
   location / {
     proxy_pass http://service:3000/;
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;

--- a/docs/manual-guides/Nginx/u_e-nginx_custom.en.md
+++ b/docs/manual-guides/Nginx/u_e-nginx_custom.en.md
@@ -87,7 +87,7 @@ server {
 
   location / {
     proxy_pass http://service:3000/;
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;

--- a/docs/third_party/portainer/third_party-portainer.de.md
+++ b/docs/third_party/portainer/third_party-portainer.de.md
@@ -33,7 +33,7 @@ map $http_upgrade $connection_upgrade {
 ```
   location /portainer/ {
     proxy_http_version 1.1;
-    proxy_set_header Host              $http_host;   # required for docker client's sake
+    proxy_set_header Host              $host;   # required for docker client's sake
     proxy_set_header X-Real-IP         $remote_addr; # pass on real client's IP
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;

--- a/docs/third_party/portainer/third_party-portainer.en.md
+++ b/docs/third_party/portainer/third_party-portainer.en.md
@@ -33,7 +33,7 @@ map $http_upgrade $connection_upgrade {
 ```
   location /portainer/ {
     proxy_http_version 1.1;
-    proxy_set_header Host              $http_host;   # required for docker client's sake
+    proxy_set_header Host              $host;   # required for docker client's sake
     proxy_set_header X-Real-IP         $remote_addr; # pass on real client's IP
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
This commit updates the documentation to provide crucial configuration adjustments for Nginx reverse proxies utilizing HTTP/3, specifically addressing SOGo redirect issues within Mailcow.

Two key nginx areas are covered:

1.  `reuseport` Directive Management:
    The `reuseport` directive, while useful for opening UDP port on the same as the TCP port on a virtual server instance, should only be used once (like always with `default_server`) when used in HTTP/3 configurations. Disabling `reuseport` except for one occurrence has resolved issues where nginx reports errors `...: duplicate listen options for 0.0.0.0:443 in /etc/nginx/...`.

2.  Correct Host Resolution for SOGo Redirects:
    After a successful login, SOGo issues 302 temporary redirects to the user's mailbox. With HTTP/3, the `proxy_set_header Host $http_host;` directive result in SOGo generating redirects with an incorrect or missing hostname (e.g., `https:///SOGo/...`). Switching to `proxy_set_header Host $host;` ensures the correct hostname is passed to SOGo, allowing it to construct accurate redirect URLs.

- mailcow/mailcow-dockerized#5411
- mailcow/mailcow-dockerized#2468

These clarifications will help users configure their Nginx reverse proxies to maintain seamless SOGo functionality when enabling HTTP/3.
