### PR TITLE
Add external reverse proxy ACME challenge passthrough for Caddy

### DIFF
--- a/docs/post_installation/reverse-proxy/r_p-caddy2.en.md
+++ b/docs/post_installation/reverse-proxy/r_p-caddy2.en.md
@@ -67,7 +67,7 @@ This script could be called as a cronjob every hour:
 0 * * * * /bin/bash /path/to/script/deploy-certs.sh  >/dev/null 2>&1
 ```
 
-Alternatively, if you are using Caddy as an external reverse proxy and do not wish for it to manage the certs for Mailcow, you may include a line to pass through the ACME challenges to mailcow-acme to allow it to manage certificates.
+Alternatively, if you are using Caddy as an external reverse proxy and do not wish for it to manage the certs for Mailcow, you may include some lines to pass through the ACME challenges to acme-mailcow to allow it to manage certificates. Note that this configuration is only to allow the ACME client to fetch SSL certificates for other functions such as IMAP, etc. Caddy will still be performing the actual SSL/TLS termination, SSL certificate management and traffic forwarding for HTTP/HTTPS.
 
 ``` hl_lines="1 3 13"
 
@@ -85,6 +85,10 @@ MAILCOW_HOSTNAME autodiscover.MAILCOW_HOSTNAME autoconfig.MAILCOW_HOSTNAME {
 
         handle /.well-known/acme-challenge* {
             root * /acme
+        }
+
+        handle /var/www/acme* {
+            root * /var/www
         }
 
         reverse_proxy 127.0.0.1:HTTP_BIND


### PR DESCRIPTION
Hello!

I recently spent some time configuring my Caddy reverse proxy (which is external and not on my docker host as it is a VM, and Caddy runs as an LXC on a hypervisor) to pass through ACME challenges. From what I understand, this is not an uncommon setup, so I figured i would include the relevant lines in the documentation in case someone else wants to allow acme-mailcow to manage certs to mailcow (since you can't pull SSL certs across LXCs/VMs very easily).

I have tested this config and confirmed that Caddy is correctly passing through the challenges to mailcow-acme and it is able to solve them.