### PR TITLE
update Dovecot CE wiki urls

### DIFF
--- a/docs/manual-guides/Dovecot/u_e-dovecot-expunge.de.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-expunge.de.md
@@ -1,4 +1,4 @@
-Wenn Sie alte Mails aus den Ordnern `.Junk` oder `.Trash` löschen wollen oder vielleicht alle gelesenen Mails, die älter als eine bestimmte Zeitspanne sind, können Sie das dovecot-Tool doveadm [man doveadm-expunge](https://wiki.dovecot.org/Tools/Doveadm/Expunge) verwenden.
+Wenn Sie alte Mails aus den Ordnern `.Junk` oder `.Trash` löschen wollen oder vielleicht alle gelesenen Mails, die älter als eine bestimmte Zeitspanne sind, können Sie das dovecot-Tool doveadm [man doveadm-expunge](https://doc.dovecot.org/latest/core/man/doveadm-expunge.1.html) verwenden.
 
 ## Der manuelle Weg
 
@@ -62,7 +62,7 @@ Löschen von Mails in einem benutzerdefinierten Ordner **innerhalb** des Postein
     ```
 
 !!! info
-    Für mögliche [Zeitspannen](https://wiki.dovecot.org/Tools/Doveadm/SearchQuery#section_date_specification) oder [SearchQuery](https://wiki.dovecot.org/Tools/Doveadm/SearchQuery#section_search_keys) schauen Sie bitte in [man doveadm-search-query](https://wiki.dovecot.org/Tools/Doveadm/SearchQuery)
+    Für mögliche [Zeitspannen](https://doc.dovecot.org/latest/core/man/doveadm-search-query.7.html#date-specification) oder [SearchQuery](https://doc.dovecot.org/latest/core/man/doveadm-search-query.7.html#search-keys) schauen Sie bitte in [man doveadm-search-query](https://doc.dovecot.org/latest/core/man/doveadm-search-query.7.html)
 
 ## Job-Scheduler
 

--- a/docs/manual-guides/Dovecot/u_e-dovecot-expunge.en.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-expunge.en.md
@@ -1,4 +1,4 @@
-If you want to delete old mails out of the `.Junk` or `.Trash` folders or maybe delete all read mails that are older than a certain amount of time you may use dovecot's tool doveadm [man doveadm-expunge](https://wiki.dovecot.org/Tools/Doveadm/Expunge).
+If you want to delete old mails out of the `.Junk` or `.Trash` folders or maybe delete all read mails that are older than a certain amount of time you may use dovecot's tool doveadm [man doveadm-expunge](https://doc.dovecot.org/latest/core/man/doveadm-expunge.1.html).
 
 ## The manual way
 
@@ -61,7 +61,7 @@ Delete mails inside a custom folder **inside** a user's inbox that are **not** f
     ```
 
 !!! info
-    For possible [time spans](https://wiki.dovecot.org/Tools/Doveadm/SearchQuery#section_date_specification) or [search keys](https://wiki.dovecot.org/Tools/Doveadm/SearchQuery#section_search_keys) have a look at [man doveadm-search-query](https://wiki.dovecot.org/Tools/Doveadm/SearchQuery)
+    For possible [time spans](https://doc.dovecot.org/latest/core/man/doveadm-search-query.7.html#date-specification) or [search keys](https://doc.dovecot.org/latest/core/man/doveadm-search-query.7.html#search-keys) have a look at [man doveadm-search-query](https://doc.dovecot.org/latest/core/man/doveadm-search-query.7.html)
 
 ## Job scheduler
 

--- a/docs/manual-guides/Dovecot/u_e-dovecot-idle_interval.de.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-idle_interval.de.md
@@ -1,6 +1,6 @@
 # Ändern des IMAP-IDLE-Intervalls
 ## Was ist das IDLE-Intervall?
-Standardmäßig sendet Dovecot eine "Ich bin noch da"-Benachrichtigung an jeden Client, der eine offene Verbindung mit Dovecot hat, um Mails so schnell wie möglich zu erhalten, ohne sie manuell abzufragen (IMAP PUSH). Diese Benachrichtigung wird durch die Einstellung [`imap_idle_notify_interval`](https://wiki.dovecot.org/Timeouts) gesteuert, die standardmäßig auf 2 Minuten eingestellt ist. 
+Standardmäßig sendet Dovecot eine "Ich bin noch da"-Benachrichtigung an jeden Client, der eine offene Verbindung mit Dovecot hat, um Mails so schnell wie möglich zu erhalten, ohne sie manuell abzufragen (IMAP PUSH). Diese Benachrichtigung wird durch die Einstellung [`imap_idle_notify_interval`](https://doc.dovecot.org/latest/core/admin/timeouts.html) gesteuert, die standardmäßig auf 2 Minuten eingestellt ist.
 
 Ein kurzes Intervall führt dazu, dass der Client viele Nachrichten für diese Verbindung erhält, was für mobile Geräte schlecht ist, da jedes Mal, wenn das Gerät diese Nachricht erhält, die Mailing-App aufwachen muss. Dies kann zu einer unnötigen Entladung der Batterie führen.
 

--- a/docs/manual-guides/Dovecot/u_e-dovecot-idle_interval.en.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-idle_interval.en.md
@@ -1,6 +1,6 @@
 # Changing the IMAP IDLE interval
 ## What is the IDLE interval?
-Per default, Dovecot sends a "I'm still here" notification to every client that has an open connection with Dovecot to get mails as quickly as possible without manually polling it (IMAP PUSH). This notification is controlled by the setting [`imap_idle_notify_interval`](https://wiki.dovecot.org/Timeouts), which defaults to 2 minutes. 
+Per default, Dovecot sends a "I'm still here" notification to every client that has an open connection with Dovecot to get mails as quickly as possible without manually polling it (IMAP PUSH). This notification is controlled by the setting [`imap_idle_notify_interval`](https://doc.dovecot.org/latest/core/admin/timeouts.html), which defaults to 2 minutes.
 
 A short interval results in the client getting a lot of messages for this connection, which is bad for mobile devices, because every time the device receives this message, the mailing app has to wake up. This can result in unnecessary battery drain.
 

--- a/docs/manual-guides/Dovecot/u_e-dovecot-more.de.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-more.de.md
@@ -44,5 +44,5 @@ Zeige **alle Nachrichten** in **beliebigen Ordnern**, die **älter** sind als 30
 doveadm search -u 'mailbox@example.org' mailbox "*" savedbefore 30d
 ```
 
-[^1]:https://wiki.dovecot.org/Tools/Doveadm/Quota
-[^2]:https://wiki.dovecot.org/Tools/Doveadm/Search
+[^1]:https://doc.dovecot.org/latest/core/man/doveadm-quota.1.html
+[^2]:https://doc.dovecot.org/latest/core/man/doveadm-search.1.html

--- a/docs/manual-guides/Dovecot/u_e-dovecot-more.en.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-more.en.md
@@ -44,5 +44,5 @@ Show **all messages** in **any folder** that are **older** then 30 days for `mai
 doveadm search -u 'mailbox@example.org' mailbox "*" savedbefore 30d
 ```
 
-[^1]:https://wiki.dovecot.org/Tools/Doveadm/Quota
-[^2]:https://wiki.dovecot.org/Tools/Doveadm/Search
+[^1]:https://doc.dovecot.org/latest/core/man/doveadm-quota.1.html
+[^2]:https://doc.dovecot.org/latest/core/man/doveadm-search.1.html

--- a/docs/manual-guides/Dovecot/u_e-dovecot-performance.de.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-performance.de.md
@@ -1,6 +1,6 @@
 ## maildir_very_dirty_syncs
 
-Dovecot's [`maildir_very_dirty_syncs`](https://wiki.dovecot.org/MailLocation/Maildir#Optimizations) Option ist seit mailcow Release 2023-05 standardmäßig aktiviert. Diese Option kann die Leistung von Postfächern, die sehr große Ordner (über 100.000 E-Mails) enthalten, erheblich verbessern.
+Dovecot's [`maildir_very_dirty_syncs`](https://doc.dovecot.org/latest/core/config/mailbox_formats/maildir.html#maildir_very_dirty_syncs) Option ist seit mailcow Release 2023-05 standardmäßig aktiviert. Diese Option kann die Leistung von Postfächern, die sehr große Ordner (über 100.000 E-Mails) enthalten, erheblich verbessern.
 
 Mit dieser Option wird vermieden, dass beim Laden einer E-Mail das gesamte `cur`-Verzeichnis erneut durchsucht wird. Wenn diese Option deaktiviert ist, geht Dovecot auf Nummer sicher und durchsucht das **gesamte** `cur`-Verzeichnis (vergleichbar mit dem Ausführen eines `ls`), um zu prüfen, ob diese bestimmte E-Mail berührt (umbenannt, etc.) wurde, indem es nach allen Dateien sucht, deren Namen die richtige ID enthalten. Dies ist sehr langsam, wenn das Verzeichnis groß ist, selbst auf Dateisystemen, die für solche Anwendungsfälle optimiert sind (wie ext4 mit aktiviertem `dir_index`) auf schnellen SSD-Laufwerken.
 

--- a/docs/manual-guides/Dovecot/u_e-dovecot-performance.en.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-performance.en.md
@@ -1,6 +1,6 @@
 ## maildir_very_dirty_syncs
 
-Dovecot's [`maildir_very_dirty_syncs` option](https://wiki.dovecot.org/MailLocation/Maildir#Optimizations) is enabled by default since mailcow Release 2023-05. This option can significantly improve the performance of mailboxes that contain very large folders (over 100,000 emails).
+Dovecot's [`maildir_very_dirty_syncs` option](https://doc.dovecot.org/latest/core/config/mailbox_formats/maildir.html#maildir_very_dirty_syncs) is enabled by default since mailcow Release 2023-05. This option can significantly improve the performance of mailboxes that contain very large folders (over 100,000 emails).
 
 What this option does is it avoids rescanning the entire `cur` directory whenever loading an email. With this option disabled, Dovecot takes it safe and scans the **entire** `cur` directory (comparable with running an `ls`) to check if that particular email was touched (renamed, etc), by looking for all files whose names contain the correct ID. This is very slow if the directory is large, even on filesystems optimized for such use cases (such as ext4 with `dir_index` enabled) on fast SSD drives.
 

--- a/docs/post_installation/firststeps-ssl.de.md
+++ b/docs/post_installation/firststeps-ssl.de.md
@@ -215,7 +215,7 @@ Setzen Sie `ENABLE_SSL_SNI=y` in "mailcow.conf" und erstellen Sie "acme-mailcow"
     ```
 
 !!! warning "Warnung"
-    Nicht alle Clients unterstützen SNI, [siehe Dovecot Dokumentation](https://wiki.dovecot.org/SSL/SNIClientSupport) oder [Wikipedia](https://en.wikipedia.org/wiki/Server_Name_Indication#Support).
+    Nicht alle Clients unterstützen SNI, [siehe Dovecot Dokumentation](https://doc.dovecot.org/latest/howto/ssl/sni_support.html) oder [Wikipedia](https://en.wikipedia.org/wiki/Server_Name_Indication#Support).
     Sie sollten sicherstellen, dass diese Clients den `MAILCOW_HOSTNAME` für sichere Verbindungen verwenden, wenn Sie diese Funktion aktivieren.
 
 Hier ist ein Beispiel:

--- a/docs/post_installation/firststeps-ssl.en.md
+++ b/docs/post_installation/firststeps-ssl.en.md
@@ -215,7 +215,7 @@ Set `ENABLE_SSL_SNI=y` in "mailcow.conf" and recreate "acme-mailcow" with:
     ```
 
 !!! warning
-    Not all clients support SNI, [see Dovecot documentation](https://wiki.dovecot.org/SSL/SNIClientSupport) or [Wikipedia](https://en.wikipedia.org/wiki/Server_Name_Indication#Support).
+    Not all clients support SNI, [see Dovecot documentation](https://doc.dovecot.org/latest/howto/ssl/sni_support.html) or [Wikipedia](https://en.wikipedia.org/wiki/Server_Name_Indication#Support).
     You should make sure these clients use the `MAILCOW_HOSTNAME` for secure connections if you enable this feature.
 
 Here is an example:


### PR DESCRIPTION
Hi!

The [old dovecot wiki](https://wiki.dovecot.org) is "closed", but I tried to cross-check the new CE docs with the old wiki from [Wayback Machine](http://web.archive.org/)
I used `/latest` instead of `/2.4.3` (which is the exact same version we use) , but I hope the links will be more future-proof this way.
I wasn't 100% sure about this old URL: https://web.archive.org/web/20190426162657/https://wiki.dovecot.org/MailLocation/Maildir#Optimizations
So I had to choose one of these:
https://doc.dovecot.org/latest/core/config/quick.html#maildir
https://doc.dovecot.org/latest/core/summaries/settings.html#maildir_very_dirty_syncs
https://doc.dovecot.org/latest/core/config/mailbox_formats/maildir.html#maildir_very_dirty_syncs
I picked the last one, but please correct me if you think another would be more appropriate.
