### PR TITLE
Update hardening for Postfix

### DIFF
--- a/docs/manual-guides/Postfix/u_e-postfix-harden_ciphers.de.md
+++ b/docs/manual-guides/Postfix/u_e-postfix-harden_ciphers.de.md
@@ -16,3 +16,63 @@ smtpd_tls_mandatory_ciphers = high
 Eine solche Konfiguration wird die aktuellen (2024-10-21) Konfigurationsprüfungen bei Diensten wie Internet.nl bestehen.
 
 Falls Sie auch die Cipher für Dovecot anpassen wollen finden Sie [hier](../Dovecot/u_e-dovecot-harden_ciphers.de.md) eine entsprechende Anleitung.
+
+!!! warning "Wichtiges Update Q2 2026"
+    Seit v1.11.0 vom 2026-04-21 von Internet.nl können Sie mit diesem Verfahren keine 100 % mehr erreichen, da diese Version die Fassung 2025-05 der NCSC-TLS-Richtlinien enthält. Bitte beachten Sie die unten beschriebene zusätzliche Konfiguration. Ohne dieses Update werden Sie für _unzureichend_ sichere Hash-Funktionen beim Schlüsselaustausch (SHA1) abgestraft.
+
+Erstellen Sie eine Datei `data/conf/postfix/openssl.cnf` mit folgendem Inhalt:
+
+```
+postfix = postfix_settings
+
+[postfix_settings]
+ssl_conf = postfix_ssl_settings
+
+[postfix_ssl_settings]
+system_default = baseline_postfix_settings
+
+[baseline_postfix_settings]
+SignatureAlgorithms = ECDSA+SHA256:ECDSA+SHA384:ECDSA+SHA512:RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA512:RSA+SHA256:RSA+SHA384
+```
+
+Fügen Sie Ihrer aktuellen `data/conf/postfix/extra.cf` Folgendes hinzu:
+
+```
+tls_config_file = /opt/postfix/conf/openssl.cnf
+tls_config_name = postfix
+```
+
+Die vollständige `extra.cf` kann nun also wie folgt aussehen:
+
+```
+tls_config_file = /opt/postfix/conf/openssl.cnf
+tls_config_name = postfix
+
+tls_high_cipherlist = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256
+tls_preempt_cipherlist = yes
+
+smtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtp_tls_ciphers = high
+smtp_tls_mandatory_ciphers = high
+
+smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtpd_tls_ciphers = high
+smtpd_tls_mandatory_ciphers = high
+```
+
+für eine ordnungsgemäß gehärtete Konfiguration. Achten Sie darauf, keine bereits vorhandenen Einstellungen zu überschreiben, die möglicherweise noch benötigt werden.
+
+Starten Sie `postfix-mailcow` neu, um Ihre Änderungen zu übernehmen:
+
+=== "docker compose (Plugin)"
+
+    ``` bash
+    docker compose restart postfix-mailcow
+    ```
+
+=== "docker-compose (Standalone)"
+
+    ``` bash
+    docker-compose restart postfix-mailcow
+    ```
+

--- a/docs/manual-guides/Postfix/u_e-postfix-harden_ciphers.de.md
+++ b/docs/manual-guides/Postfix/u_e-postfix-harden_ciphers.de.md
@@ -51,11 +51,9 @@ tls_config_name = postfix
 tls_high_cipherlist = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256
 tls_preempt_cipherlist = yes
 
-smtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtp_tls_ciphers = high
 smtp_tls_mandatory_ciphers = high
 
-smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtpd_tls_ciphers = high
 smtpd_tls_mandatory_ciphers = high
 ```

--- a/docs/manual-guides/Postfix/u_e-postfix-harden_ciphers.en.md
+++ b/docs/manual-guides/Postfix/u_e-postfix-harden_ciphers.en.md
@@ -16,3 +16,63 @@ smtpd_tls_mandatory_ciphers = high
 Such a configuration will pass current (2024-10-21) configuration checks against services like Internet.nl.
 
 If you want to adjust the ciphers for Dovecot as well you can find the corresponding tutorial [here](../Dovecot/u_e-dovecot-harden_ciphers.en.md).
+
+!!! warning "Important update Q2 2026"
+    Since v1.11.0 from 2026-04-21 of Internet.nl, you will not be able to score 100% anymore with this procedure since this version includes the 2025-05 version of the NCSC TLS guidelines. Please see below the extra configuration needed. Without this updated, you will be sanctioned for _insufficiently_ secure hash functions for key exchange (SHA1)
+
+Create a file `data/conf/postfix/openssl.cnf` with the following content:
+
+```
+postfix = postfix_settings
+
+[postfix_settings]
+ssl_conf = postfix_ssl_settings
+
+[postfix_ssl_settings]
+system_default = baseline_postfix_settings
+
+[baseline_postfix_settings]
+SignatureAlgorithms = ECDSA+SHA256:ECDSA+SHA384:ECDSA+SHA512:RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA512:RSA+SHA256:RSA+SHA384
+```
+
+Add to your current `data/conf/postfix/extra.cf` the following:
+
+```
+tls_config_file = /opt/postfix/conf/openssl.cnf
+tls_config_name = postfix
+```
+
+So the complete `extra.cf` no may read:
+
+```
+tls_config_file = /opt/postfix/conf/openssl.cnf
+tls_config_name = postfix
+
+tls_high_cipherlist = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256
+tls_preempt_cipherlist = yes
+
+smtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtp_tls_ciphers = high
+smtp_tls_mandatory_ciphers = high
+
+smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtpd_tls_ciphers = high
+smtpd_tls_mandatory_ciphers = high
+```
+
+for a properly hardened configuration. Beware not to override any existing settings you might had there if they are still needed.
+
+Restart `postfix-mailcow` to apply your changes:
+
+=== "docker compose (Plugin)"
+
+    ``` bash
+    docker compose restart postfix-mailcow
+    ```
+
+=== "docker-compose (Standalone)"
+
+    ``` bash
+    docker-compose restart postfix-mailcow
+    ```
+

--- a/docs/manual-guides/Postfix/u_e-postfix-harden_ciphers.en.md
+++ b/docs/manual-guides/Postfix/u_e-postfix-harden_ciphers.en.md
@@ -42,7 +42,7 @@ tls_config_file = /opt/postfix/conf/openssl.cnf
 tls_config_name = postfix
 ```
 
-So the complete `extra.cf` no may read:
+So the complete `extra.cf` now may read:
 
 ```
 tls_config_file = /opt/postfix/conf/openssl.cnf

--- a/docs/manual-guides/Postfix/u_e-postfix-harden_ciphers.en.md
+++ b/docs/manual-guides/Postfix/u_e-postfix-harden_ciphers.en.md
@@ -51,11 +51,9 @@ tls_config_name = postfix
 tls_high_cipherlist = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256
 tls_preempt_cipherlist = yes
 
-smtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtp_tls_ciphers = high
 smtp_tls_mandatory_ciphers = high
 
-smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtpd_tls_ciphers = high
 smtpd_tls_mandatory_ciphers = high
 ```


### PR DESCRIPTION
Since v1.11.0 from 2026-04-21 of Internet.nl, you will not be able to score 100% anymore with this procedure since this version includes the 2025-05 version of the NCSC TLS guidelines.  Without this updated, you will be sanctioned for insufficiently secure hash functions for key exchange (SHA1).

This updates the initial postfix hardening doc I posted in 2024 to reflect these new changes.

This is also related to issue [#7208](https://github.com/mailcow/mailcow-dockerized/issues/7208#issuecomment-4377264431) . The ciphers are hardened though as opposed to that proposed version to be better future ready. Also relates to external issue [#1553](https://github.com/internetstandards/Internet.nl/issues/1553#issuecomment-4313082980).

The German version has been machine translated so you might want to double-check this.