### PR TITLE
Lazy expunge documentation update

### DIFF
--- a/docs/manual-guides/Dovecot/u_e-dovecot-lazy_expunge.de.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-lazy_expunge.de.md
@@ -5,7 +5,7 @@
     Diese Funktion ist ab mailcow-Versionen 2024-11 kompatibel. Ältere Versionen sind theoretisch ebenfalls in der Lage, die Funktion zu nutzen. Aufgrund interner Änderungen ist die Implementierung jedoch schwieriger und wird hier nicht weiter beschrieben, da nicht unterstüzt.
 
 ## Vorwort
-Dovecot unterstützt seit [geraumer Zeit](https://doc.dovecot.org/2.3/configuration_manual/lazy_expunge_plugin/) eine Funktion namens *Lazy Expunge*, welche es dem Serveradministrator ermöglicht, gelöschte E-Mails eines Benutzerkontos nach der eigentlichen Löschung zurückzuhalten.
+Dovecot unterstützt seit [geraumer Zeit](https://doc.dovecot.org/2.4.4/core/plugins/lazy_expunge.html) eine Funktion namens *Lazy Expunge*, welche es dem Serveradministrator ermöglicht, gelöschte E-Mails eines Benutzerkontos nach der eigentlichen Löschung zurückzuhalten.
 
 mailcow besitzt eine ähnliche Funktion, die jedoch für Benutzer nicht so leicht zugänglich ist (siehe [Versehentlich gelöschte Daten wiederherstellen (Mail)](../../backup_restore/b_n_r-accidental_deletion.de.md#mail)) und eher als Fallback-Methode für Administratoren dient.
 

--- a/docs/manual-guides/Dovecot/u_e-dovecot-lazy_expunge.de.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-lazy_expunge.de.md
@@ -15,14 +15,6 @@ Mit der Dovecot-Option können Benutzer selbst als gelöscht markierte E-Mails e
 
 1. Bearbeiten Sie die `extra.conf` im Dovecot-Konfigurationsordner (in der Regel unter `MAILCOW_ROOT/data/conf/dovecot`) mit folgendem Inhalt:
     ```bash
-    plugin {
-        # Kopiere alle gelöschten Mails in die .EXPUNGED Mailbox
-        lazy_expunge = .EXPUNGED
-
-        # Als gelöscht markierte Mails von der Quota ausschließen
-        quota_rule = .EXPUNGED:ignore
-    }
-
     # Definiert die .EXPUNGED Mailbox
     namespace inbox {
         mailbox .EXPUNGED {
@@ -32,6 +24,24 @@ Mit der Dovecot-Option können Benutzer selbst als gelöscht markierte E-Mails e
             # Definiert, wie viele Mails maximal in der EXPUNGED Mailbox gehalten werden sollen, bevor diese geleert wird
             autoexpunge_max_mails = 100000
         }
+    }
+
+    # Activate lazy_expunge plugin
+    protocol imap {
+        mail_plugins = $mail_plugins lazy_expunge
+    }
+
+    plugin {
+        # Kopiere alle gelöschten Mails in die .EXPUNGED Mailbox
+        # Siehe: https://doc.dovecot.org/2.4.2/core/plugins/lazy_expunge.html#storage-locations
+        lazy_expunge = .EXPUNGED
+        lazy_expunge_mailbox = .EXPUNGED
+        
+        # Kopiere nur die letzte Instanz, um Duplikate zu vermeiden
+        lazy_expunge_only_last_instance = yes
+
+        # Als gelöscht markierte Mails von der Quota ausschließen
+        quota_rule = .EXPUNGED:ignore
     }
     ```
 

--- a/docs/manual-guides/Dovecot/u_e-dovecot-lazy_expunge.de.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-lazy_expunge.de.md
@@ -19,7 +19,7 @@ Mit der Dovecot-Option können Benutzer selbst als gelöscht markierte E-Mails e
     namespace inbox {
         mailbox .EXPUNGED {
             # Definiert, wie lange Mails in diesem Ordner bleiben sollen, bevor sie gelöscht werden. 
-            # Zeit wird definiert nach: https://doc.dovecot.org/2.3/settings/types/#time
+            # Zeit wird definiert nach: https://doc.dovecot.org/2.4.4/core/settings/types#time
             autoexpunge = 7days
             # Definiert, wie viele Mails maximal in der EXPUNGED Mailbox gehalten werden sollen, bevor diese geleert wird
             autoexpunge_max_mails = 100000
@@ -33,7 +33,7 @@ Mit der Dovecot-Option können Benutzer selbst als gelöscht markierte E-Mails e
 
     plugin {
         # Kopiere alle gelöschten Mails in die .EXPUNGED Mailbox
-        # Siehe: https://doc.dovecot.org/2.4.2/core/plugins/lazy_expunge.html#storage-locations
+        # Siehe: https://doc.dovecot.org/2.4.4/core/plugins/lazy_expunge.html#storage-locations
         lazy_expunge = .EXPUNGED
         lazy_expunge_mailbox = .EXPUNGED
         

--- a/docs/manual-guides/Dovecot/u_e-dovecot-lazy_expunge.en.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-lazy_expunge.en.md
@@ -18,7 +18,7 @@ With the Dovecot option, users can view and restore emails that have been marked
     # Define the .EXPUNGED mailbox
     namespace inbox {
         mailbox .EXPUNGED {
-            # Define how long emails will stay in this folder before they are deleted. Time is defined according to: https://doc.dovecot.org/2.3/settings/types/#time
+            # Define how long emails will stay in this folder before they are deleted. Time is defined according to: https://doc.dovecot.org/2.4.4/core/settings/types#time
             autoexpunge = 7days
             # Define how many emails can be kept in the EXPUNGED folder before it is cleared
             autoexpunge_max_mails = 100000
@@ -32,7 +32,7 @@ With the Dovecot option, users can view and restore emails that have been marked
 
     plugin {
         # Copy all deleted emails to the .EXPUNGED mailbox
-        # See https://doc.dovecot.org/2.4.2/core/plugins/lazy_expunge.html#storage-locations
+        # For custom storage choice see: https://doc.dovecot.org/2.4.4/core/plugins/lazy_expunge.html#storage-locations
         lazy_expunge = .EXPUNGED
         lazy_expunge_mailbox = .EXPUNGED
 

--- a/docs/manual-guides/Dovecot/u_e-dovecot-lazy_expunge.en.md
+++ b/docs/manual-guides/Dovecot/u_e-dovecot-lazy_expunge.en.md
@@ -5,7 +5,7 @@
     This feature is compatible with mailcow versions starting from 2024-11. Older versions are theoretically capable of using it as well, but due to internal changes, the implementation is more complicated, so it won't be stated here as unsupported.
 
 ## Introduction
-Dovecot has supported a feature called *Lazy Expunge* for [quite some time](https://doc.dovecot.org/2.3/configuration_manual/lazy_expunge_plugin/), which allows server administrators to temporarily retain deleted emails from a user account even after they have been deleted.
+Dovecot has supported a feature called *Lazy Expunge* for [quite some time](https://doc.dovecot.org/2.4.4/core/plugins/lazy_expunge.html), which allows server administrators to temporarily retain deleted emails from a user account even after they have been deleted.
 
 mailcow also has a similar feature, but it is not easily accessible to users (see [Recover accidentally deleted data (Mail)](../../backup_restore/b_n_r-accidental_deletion.en.md#mail)) and serves more as a fallback method for administrators.
 
@@ -15,14 +15,6 @@ With the Dovecot option, users can view and restore emails that have been marked
 
 1. Edit the `extra.conf` file in the Dovecot configuration folder (usually located at `MAILCOW_ROOT/data/conf/dovecot`) with the following content:
     ```bash
-    plugin {
-        # Copy all deleted emails to the .EXPUNGED mailbox
-        lazy_expunge = .EXPUNGED
-
-        # Exclude marked-as-deleted emails from the quota
-        quota_rule = .EXPUNGED:ignore
-    }
-
     # Define the .EXPUNGED mailbox
     namespace inbox {
         mailbox .EXPUNGED {
@@ -31,6 +23,24 @@ With the Dovecot option, users can view and restore emails that have been marked
             # Define how many emails can be kept in the EXPUNGED folder before it is cleared
             autoexpunge_max_mails = 100000
         }
+    }
+
+    # Activate lazy_expunge plugin
+    protocol imap {
+        mail_plugins = $mail_plugins lazy_expunge
+    }
+
+    plugin {
+        # Copy all deleted emails to the .EXPUNGED mailbox
+        # See https://doc.dovecot.org/2.4.2/core/plugins/lazy_expunge.html#storage-locations
+        lazy_expunge = .EXPUNGED
+        lazy_expunge_mailbox = .EXPUNGED
+
+        # Copy only last instance to avoid duplicates
+        lazy_expunge_only_last_instance = yes
+        
+        # Exclude marked-as-deleted emails from the quota
+        quota_rule = .EXPUNGED:ignore
     }
     ```
 


### PR DESCRIPTION
Hello,

After noticing that the Lazy Expunge configuration from the documentation did not work as expected, I looked into it further with the help of contributors in issue [#6558](https://github.com/mailcow/mailcow-dockerized/issues/6558) in the mailcow-dockerized repository, who provided a working solution.

This PR adds the working configuration adjustment and updates the documentation link to a more recent version of the Dovecot documentation.

PS: The German translation should be reviewed.