### PR TITLE
Fix typo in Roundcube: 'docker-compose-override.yml'

### DIFF
--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -206,7 +206,7 @@ services:
 ```
 ## Standalone-Installation
 
-Um Roundcube in einem eigenen Docker-Container zu installieren, fügen Sie Folgendes in Ihre `docker-compose.yaml`-Datei ein:
+Um Roundcube in einem eigenen Docker-Container zu installieren, fügen Sie Folgendes in Ihre `docker-compose.override.yaml`-Datei ein:
 
 ```yaml
 services:

--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -206,7 +206,7 @@ services:
 ```
 ## Standalone-Installation
 
-Um Roundcube in einem eigenen Docker-Container zu installieren, fügen Sie Folgendes in Ihre `docker-compose-override.yaml`-Datei ein:
+Um Roundcube in einem eigenen Docker-Container zu installieren, fügen Sie Folgendes in Ihre `docker-compose.yaml`-Datei ein:
 
 ```yaml
 services:

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -257,7 +257,7 @@ services:
           - roundcube-db
 
   roundcube:
-    image: roundcube/roundcubemail:1.7.2-apache # See newest version https://hub.docker.com/r/roundcube/roundcubemail/tags?name=apache
+    image: roundcube/roundcubemail:1.7.0-apache # See newest version https://hub.docker.com/r/roundcube/roundcubemail/tags?name=apache
     environment:
       IPV4_NETWORK: ${IPV4_NETWORK:-172.22.1}
       IPV6_NETWORK: ${IPV6_NETWORK:-fd4d:6169:6c63:6f77::/64}

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -236,7 +236,7 @@ services:
 
 ## Standalone Install
 
-To Install Roundcube in its own Docker Container you have to add the following into your `docker-compose.yaml` file:
+To Install Roundcube in its own Docker Container you have to add the following into your `docker-compose.override.yaml` file:
 
 ```yaml
 services:

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -236,7 +236,7 @@ services:
 
 ## Standalone Install
 
-To Install Roundcube in its own Docker Container you have to add the following into your `docker-compose-override.yaml` file:
+To Install Roundcube in its own Docker Container you have to add the following into your `docker-compose.yaml` file:
 
 ```yaml
 services:
@@ -257,7 +257,7 @@ services:
           - roundcube-db
 
   roundcube:
-    image: roundcube/roundcubemail:1.7.0-apache # See newest version https://hub.docker.com/r/roundcube/roundcubemail/tags?name=apache
+    image: roundcube/roundcubemail:1.7.2-apache # See newest version https://hub.docker.com/r/roundcube/roundcubemail/tags?name=apache
     environment:
       IPV4_NETWORK: ${IPV4_NETWORK:-172.22.1}
       IPV6_NETWORK: ${IPV6_NETWORK:-fd4d:6169:6c63:6f77::/64}


### PR DESCRIPTION
Small pr just noticed that technically the `*.override.yml` file does not work as-is, since the mailcow networks and volumes need to be attached too, so instead I propose we recommend adding it to the `docker-compose.yml` file.