### PR TITLE
Document how to fully disable outgoing TLS policy checks

### DIFF
--- a/docs/manual-guides/Postfix/u_e-postfix-tls_policy_override.de.md
+++ b/docs/manual-guides/Postfix/u_e-postfix-tls_policy_override.de.md
@@ -75,4 +75,46 @@ Ein **Neustart von mailcow oder Postfix ist nicht erforderlich** – die Änderu
 
 !!! warning "Hinweis"
     Sobald fehlerhafte TLSA-Records oder Zertifikatsprobleme auf Empfängerseite behoben wurden, sollten Sie die temporär gesetzte Richtlinie **wieder entfernen oder auf den Standardwert zurücksetzen**, um die Integrität des TLS-Sicherheitsmodells zu gewährleisten.
+
+---
+
+## TLS-Richtlinienprüfung vollständig deaktivieren
+
+In seltenen Fällen reicht eine Richtlinie pro Domain nicht aus - etwa wenn eine Firewall mit SMTP-Inspection (Cisco ASA `inspect esmtp`, FortiGate SMTP-Proxy und ähnliche) oder ein zwischengeschaltetes Relay Ihres Providers `STARTTLS` aus der EHLO-Antwort des Gegenübers entfernt. Postfix sieht dann einen Server, der überhaupt kein TLS anbietet, während DANE oder MTA-STS es weiterhin verlangen, und jede betroffene E-Mail bleibt in der Warteschlange liegen.
+
+Um die Prüfung für alle Ziele abzuschalten, fügen Sie Folgendes in die Postfix [extra.cf](u_e-postfix-extra_cf.de.md) ein:
+
+```bash
+smtp_tls_security_level = may
+smtp_dns_support_level = enabled
+smtp_tls_policy_maps = proxy:mysql:/opt/postfix/conf/sql/mysql_tls_policy_override_maps.cf
+```
+
+- `smtp_tls_security_level = may` - opportunistisches TLS: verschlüsselt, wenn der Zielserver `STARTTLS` anbietet, andernfalls wird unverschlüsselt zugestellt. Der mailcow-Standard ist `dane`.
+- `smtp_dns_support_level = enabled` - einfache DNS-Abfragen anstelle der DNSSEC-validierten, die nur für DANE benötigt werden. Der mailcow-Standard ist `dnssec`.
+- `smtp_tls_policy_maps` - derselbe Wert wie in der `main.cf`, jedoch ohne den Eintrag `socketmap:inet:postfix-tlspol:8642:QUERY`, sodass Postfix postfix-tlspol nicht mehr nach MTA-STS- und DANE-Richtlinien fragt. Die oben beschriebenen TLS-Richtlinien aus der mailcow-UI funktionieren weiterhin.
+
+Ohne `smtp_dns_support_level = dnssec` weist Postfix die Richtlinien `dane` und `dane-only` zurück, kombinieren Sie diese Einstellung daher nicht mit solchen Einträgen in der TLS-Richtlinientabelle.
+
+Starten Sie Postfix neu, um die Änderung zu übernehmen:
+
+=== "docker compose (Plugin)"
+
+    ``` bash
+    docker compose restart postfix-mailcow
+    ```
+
+=== "docker-compose (Standalone)"
+
+    ``` bash
+    docker-compose restart postfix-mailcow
+    ```
+
+Lassen Sie den Container `postfix-tlspol-mailcow` laufen, `postfix-mailcow` hängt von ihm ab. Er erhält lediglich keine Anfragen mehr.
+
+!!! info "Geltungsbereich"
+    Diese `smtp_*`-Parameter gelten ausschließlich für **ausgehende** Zustellungen von Postfix an andere Mailserver über Port 25. Eingehende E-Mails, die Einlieferung über Port 465/587 sowie die TLS-Erzwingung pro Mailbox bleiben unberührt.
+
+!!! warning "Hinweis"
+    Das Deaktivieren der Prüfung entfernt den Downgrade-Schutz für **alle** Empfänger, ein Angreifer auf dem Übertragungsweg kann `STARTTLS` dann unbemerkt entfernen. Verwenden Sie eine Richtlinie pro Domain, solange das Problem einzelne Empfänger betrifft, und greifen Sie nur dann hierauf zurück, wenn Ihr gesamter ausgehender Verkehr betroffen ist.
  

--- a/docs/manual-guides/Postfix/u_e-postfix-tls_policy_override.en.md
+++ b/docs/manual-guides/Postfix/u_e-postfix-tls_policy_override.en.md
@@ -75,4 +75,46 @@ A **restart of mailcow or Postfix is not required** — the change takes effect 
 
 !!! warning "Note"
       As soon as faulty TLSA records or certificate issues on the recipient side are resolved, you should **remove the temporarily set policy or reset it to the default value** to preserve the integrity of the TLS security model.
+
+---
+
+## Disabling the TLS policy checks completely
+
+In rare cases a per-domain override is not enough - for example if a firewall with SMTP inspection (Cisco ASA `inspect esmtp`, FortiGate SMTP proxy and similar) or an intercepting relay at your provider removes `STARTTLS` from the EHLO response of the remote server. Postfix then sees a server that offers no TLS at all, while DANE or MTA-STS still demand it, and every affected mail stays in the queue.
+
+To switch the checks off for all destinations, add the following to Postfix [extra.cf](u_e-postfix-extra_cf.en.md):
+
+```bash
+smtp_tls_security_level = may
+smtp_dns_support_level = enabled
+smtp_tls_policy_maps = proxy:mysql:/opt/postfix/conf/sql/mysql_tls_policy_override_maps.cf
+```
+
+- `smtp_tls_security_level = may` - opportunistic TLS: encrypt if the remote server offers `STARTTLS`, deliver unencrypted if it does not. The mailcow default is `dane`.
+- `smtp_dns_support_level = enabled` - plain DNS lookups instead of the DNSSEC-validated ones, which are only needed for DANE. The mailcow default is `dnssec`.
+- `smtp_tls_policy_maps` - same value as in `main.cf`, but without the `socketmap:inet:postfix-tlspol:8642:QUERY` entry, so Postfix no longer asks postfix-tlspol for MTA-STS and DANE policies. The TLS policy entries from the mailcow UI described above keep working.
+
+Without `smtp_dns_support_level = dnssec` Postfix refuses the `dane` and `dane-only` policies, so do not combine this with such entries in the TLS policy table.
+
+Restart Postfix to apply the change:
+
+=== "docker compose (Plugin)"
+
+    ``` bash
+    docker compose restart postfix-mailcow
+    ```
+
+=== "docker-compose (Standalone)"
+
+    ``` bash
+    docker-compose restart postfix-mailcow
+    ```
+
+Keep the `postfix-tlspol-mailcow` container running, `postfix-mailcow` depends on it. It simply stops receiving queries.
+
+!!! info "Scope"
+      These `smtp_*` parameters only apply to **outgoing** deliveries from Postfix to other mail servers on port 25. Incoming mail, submission on port 465/587 and the per-mailbox "TLS enforcement in/out" settings are not affected.
+
+!!! warning "Note"
+      Disabling the checks removes the downgrade protection for **all** recipients, an attacker on the path can then strip `STARTTLS` unnoticed. Use a per-domain policy whenever the problem is limited to single recipients and only fall back to this if your entire outgoing traffic is affected.
  


### PR DESCRIPTION
The TLS-Policy override guide only explained how to change the policy for a single destination. Where a firewall with SMTP inspection or an intercepting relay removes STARTTLS from the EHLO response, no per-domain entry helps and mail piles up in the queue.

Add a section to the English and German guide describing the extra.cf overrides that drop the postfix-tlspol socketmap and fall back to opportunistic TLS, including the scope of the change and the security implications.