### PR TITLE
Update nginx http2 directive syntax

### DIFF
--- a/docs/post_installation/reverse-proxy/r_p-nginx.de.md
+++ b/docs/post_installation/reverse-proxy/r_p-nginx.de.md
@@ -13,8 +13,9 @@ server {
   return 301 https://$host$request_uri;
 }
 server {
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
   server_name ZU MAILCOW HOSTNAMEN ÄNDERN autodiscover.* autoconfig.*;
 
   ssl_certificate MAILCOW_PATH/data/assets/ssl/cert.pem;

--- a/docs/post_installation/reverse-proxy/r_p-nginx.en.md
+++ b/docs/post_installation/reverse-proxy/r_p-nginx.en.md
@@ -13,8 +13,9 @@ server {
   return 301 https://$host$request_uri;
 }
 server {
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
   server_name CHANGE_TO_MAILCOW_HOSTNAME autodiscover.* autoconfig.*;
 
   ssl_certificate MAILCOW_PATH/data/assets/ssl/cert.pem;


### PR DESCRIPTION
The documentation still suggests a deprecated syntax (at least since [nginx 1.25.1](https://redirect.github.com/mailcow/mailcow-dockerized/pull/5365)?) for the `http2` module, is there any reason to still keep it?

The suggested configuration emits a warning:
```
2026/08/23 09:57:52 [warn] 3499126#3499126: the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/sites-enabled/$HOST.conf
```

Thanks for a review.

---

(Note: that snippet of documentation suggests code that (under some circumstances) causes also another warning, but I'll keep the two issues separated)