### PR TITLE
Add tip about possible nginx warning

### DIFF
--- a/docs/post_installation/reverse-proxy/r_p-nginx.de.md
+++ b/docs/post_installation/reverse-proxy/r_p-nginx.de.md
@@ -62,3 +62,11 @@ Beim Einsatz eines Proxys in einem anderen Subnetz müssen Sie die folgende Umge
 ```
 TRUSTED_PROXIES=#.#.#.#
 ```
+
+!!! tip "Tipp"
+    Wenn der Befehl `nginx -t` eine Warnung ähnlich der folgenden ausgibt:
+    > protocol options redefined for [::]:443
+
+    das bedeutet, dass es in Ihrer globalen Nginx-Konfiguration einen weiteren virtuellen Host mit `listen [::]:HOST_PORT` gibt.
+
+    Die Warnung ist meist harmlos, aber vielleicht möchten Sie trotzdem nachsehen, wie man das Problem beheben kann.

--- a/docs/post_installation/reverse-proxy/r_p-nginx.en.md
+++ b/docs/post_installation/reverse-proxy/r_p-nginx.en.md
@@ -62,3 +62,11 @@ When using a proxy on a different subnet you will need to add the following envi
 ```
 TRUSTED_PROXIES=#.#.#.#
 ```
+
+!!! tip
+    If the command `nginx -t` returns a warning similar to:
+    > protocol options redefined for [::]:443
+
+    it means that in your global nginx configuration there's the another virtual host with `listen [::]:HOST_PORT`.
+
+    The warning is mostly harmless but you might want to investigate how to fix it.


### PR DESCRIPTION
The mailcow documentation suggests:
```
  listen 80 default_server;
  listen [::]:80 default_server;
```

After configuring my nginx for malcow, I started seeing this warning:
```
2026/08/23 09:57:52 [warn] 3499126#3499126: protocol options redefined for [::]:443 in /etc/nginx/sites-enabled/$HOST.conf:12
```

After looking around, this [Stack Overflow answer](https://serverfault.com/questions/1131318/nginx-warn-protocol-options-redefined) pointed in the right direction. I have multiple virtual hosts and I manage my SSL certs outside of the mailcow Docker containers (thus the warning on port 443 instead of 80). Another vhost config file has the same config line (on port 443) and to fix the warning I changed the other vhost configuration.

My config perhaps deviates a bit from the documentation but given that this warning might be somwehat cryptic, would it make sense adding a small tip in the docs? Just my .2 cents, probably it's not too important.

Note: I am not German mother-tongue so my German translation might not be perfect :)

Thanks for an opinion!