### PR TITLE
Fix : Sogo links in mailcow third party roundcube integration #979

### DIFF
--- a/docs/third_party/roundcube/third_party-roundcube.de.md
+++ b/docs/third_party/roundcube/third_party-roundcube.de.md
@@ -499,7 +499,7 @@ Sie können den Roundcube-Link zur mailcow-App-Liste hinzufügen. Öffnen oder e
 $MAILCOW_APPS = [
     [
         'name' => 'SOGo',
-        'link' => '/SOGo/'
+        'link' => '/SOGo/so/'
     ],
     [
         'name' => 'Roundcube',

--- a/docs/third_party/roundcube/third_party-roundcube.en.md
+++ b/docs/third_party/roundcube/third_party-roundcube.en.md
@@ -556,7 +556,7 @@ block:
 $MAILCOW_APPS = [
     [
         'name' => 'SOGo',
-        'link' => '/SOGo/'
+        'link' => '/SOGo/so/'
     ],
     [
         'name' => 'Roundcube',


### PR DESCRIPTION
Fix issue #979 

```diff
-        'link' => '/SOGo/'
+        'link' => '/SOGo/so/'
```