### PR TITLE
Adding third party tool - mailcow Alias Generator

### DIFF
--- a/docs/third_party/mailcow-alias-generator/third_party-mailcow-alias-generator.de.md
+++ b/docs/third_party/mailcow-alias-generator/third_party-mailcow-alias-generator.de.md
@@ -1,0 +1,92 @@
+# mailcow Alias Generator
+
+[mailcow Alias Generator](https://github.com/Upellift99/mailcow-alias-generator) ist eine kleine,
+selbst gehostete Webanwendung, die E-Mail-Aliase über die mailcow-API anlegt. Damit erhält jeder
+Dienst seinen eigenen Wegwerf-Alias (z. B. `supabase1234@example.com`), der an Ihr echtes Postfach
+weiterleitet — nützlich, um Anmeldungen voneinander zu trennen und zu erkennen, welcher Dienst
+Ihre Adresse weitergegeben hat.
+
+## Funktionen
+
+- Alias-Erstellung mit einem Klick, mit zufälliger Endung, Live-Vorschau und QR-Code
+- Mehrere Domains, auswählbar über ein Dropdown-Menü
+- Mehrbenutzerfähig (eigenes Passwort und eigene Standard-Weiterleitung je Benutzer)
+- Gehashte Passwörter, Rate-Limiting bei der Anmeldung und optional das datenschutzfreundliche
+  [ALTCHA](https://altcha.org/)-Captcha
+- Veröffentlichtes Docker-Image und Bereitstellung per Docker Compose
+
+## Voraussetzungen
+
+- Eine erreichbare mailcow-Instanz mit aktivierter API
+- Ein mailcow-API-Schlüssel mit **Lese-/Schreibrechten** auf `alias` (und Leserechten auf `domains`)
+- Docker und Docker Compose auf dem Host, der die Anwendung ausführt
+
+!!! warning "Schützen Sie den API-Schlüssel"
+    Die Anwendung speichert Ihren mailcow-API-Schlüssel in ihrer `config.json`. Binden Sie diese
+    Datei schreibgeschützt ein, beschränken Sie den Zugriff auf die Anwendung (Reverse Proxy +
+    HTTPS, Firewall/VPN) und verwenden Sie gehashte Passwörter.
+
+## Installation
+
+Ein vorgefertigtes Image wird in der GitHub Container Registry veröffentlicht. Das Repository muss
+daher nicht geklont werden — es werden nur eine `docker-compose.yml` und eine `config.json`
+benötigt:
+
+``` bash
+mkdir mailcow-alias-generator && cd mailcow-alias-generator
+
+# Compose-Datei und Konfigurationsvorlage herunterladen
+curl -O https://raw.githubusercontent.com/Upellift99/mailcow-alias-generator/main/docker-compose.yml
+curl -o config.json https://raw.githubusercontent.com/Upellift99/mailcow-alias-generator/main/config.sample.json
+```
+
+Tragen Sie in der `config.json` Ihre `mailcow_url`, den API-Schlüssel, die Domains und die Benutzer
+ein und starten Sie die Anwendung:
+
+=== "docker compose (Plugin)"
+
+    ``` bash
+    docker compose up -d
+    ```
+
+=== "docker-compose (Standalone)"
+
+    ``` bash
+    docker-compose up -d
+    ```
+
+Die Oberfläche ist anschließend über den konfigurierten Port erreichbar (Standard `5000`, festgelegt
+über `HOST_PORT`).
+
+## Konfiguration
+
+Minimale `config.json`:
+
+``` json
+{
+  "mailcow_url": "https://mail.example.com",
+  "api_key": "YOUR_MAILCOW_API_KEY",
+  "domains": ["example.com"],
+  "users": {
+    "admin": {
+      "password": "pbkdf2:sha256:...",
+      "default_redirect": "admin@example.com",
+      "description": "Administrator"
+    }
+  }
+}
+```
+
+!!! tip
+    Gehashte Passwörter erzeugen Sie mit `python generate_password_hash.py`. Die vollständige
+    Konfiguration, die Einrichtung für mehrere Benutzer und die ALTCHA-Optionen sind in der
+    [README](https://github.com/Upellift99/mailcow-alias-generator#readme) des Projekts beschrieben.
+
+## Links
+
+- Quellcode: <https://github.com/Upellift99/mailcow-alias-generator>
+- Container-Image: `ghcr.io/upellift99/mailcow-alias-generator:latest`
+
+!!! note
+    Dies ist ein von der Community gepflegtes Projekt eines Drittanbieters und steht in keiner
+    Verbindung zum mailcow-Team.

--- a/docs/third_party/mailcow-alias-generator/third_party-mailcow-alias-generator.en.md
+++ b/docs/third_party/mailcow-alias-generator/third_party-mailcow-alias-generator.en.md
@@ -1,0 +1,85 @@
+# mailcow Alias Generator
+
+[mailcow Alias Generator](https://github.com/Upellift99/mailcow-alias-generator) is a small,
+self-hosted web app that creates email aliases through the mailcow API. It lets you give every
+service its own throwaway alias (e.g. `supabase1234@example.com`) that redirects to your real
+inbox — useful to compartmentalize signups and spot which service leaked your address.
+
+## Features
+
+- One-click alias creation with a random suffix, live preview and QR code
+- Multiple domains, selectable from a dropdown
+- Multi-user (per-user password and default redirect address)
+- Hashed passwords, login rate limiting, and an optional privacy-friendly [ALTCHA](https://altcha.org/) captcha
+- Published Docker image and Docker Compose deployment
+
+## Requirements
+
+- A reachable mailcow instance with the API enabled
+- A mailcow API key with **read/write** on `alias` (and read on `domains`)
+- Docker and Docker Compose on the host that will run the app
+
+!!! warning "Keep the API key safe"
+    The app stores your mailcow API key in its `config.json`. Mount that file read-only,
+    restrict access to the app (reverse proxy + HTTPS, firewall/VPN), and use hashed passwords.
+
+## Installation
+
+A pre-built image is published to the GitHub Container Registry, so there is no need to clone
+the repository — only a `docker-compose.yml` and a `config.json` are required:
+
+``` bash
+mkdir mailcow-alias-generator && cd mailcow-alias-generator
+
+# Grab the compose file and a config template
+curl -O https://raw.githubusercontent.com/Upellift99/mailcow-alias-generator/main/docker-compose.yml
+curl -o config.json https://raw.githubusercontent.com/Upellift99/mailcow-alias-generator/main/config.sample.json
+```
+
+Edit `config.json` with your `mailcow_url`, API key, domains and users, then start the app:
+
+=== "docker compose (Plugin)"
+
+    ``` bash
+    docker compose up -d
+    ```
+
+=== "docker-compose (Standalone)"
+
+    ``` bash
+    docker-compose up -d
+    ```
+
+The interface is then available on the configured port (default `5000`, set via `HOST_PORT`).
+
+## Configuration
+
+Minimal `config.json`:
+
+``` json
+{
+  "mailcow_url": "https://mail.example.com",
+  "api_key": "YOUR_MAILCOW_API_KEY",
+  "domains": ["example.com"],
+  "users": {
+    "admin": {
+      "password": "pbkdf2:sha256:...",
+      "default_redirect": "admin@example.com",
+      "description": "Administrator"
+    }
+  }
+}
+```
+
+!!! tip
+    Generate hashed passwords with `python generate_password_hash.py`. Full configuration,
+    multi-user setup and ALTCHA options are documented in the project's
+    [README](https://github.com/Upellift99/mailcow-alias-generator#readme).
+
+## Links
+
+- Source code: <https://github.com/Upellift99/mailcow-alias-generator>
+- Container image: `ghcr.io/upellift99/mailcow-alias-generator:latest`
+
+!!! note
+    This is a community-maintained, third-party project and is not affiliated with the mailcow team.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -214,6 +214,7 @@ nav:
     - 'Exchange Hybrid Setup': 'third_party/exchange_onprem/third_party-exchange_onprem.md'
     - 'Gitea': 'third_party/gitea/third_party-gitea.md'
     - 'Gogs': 'third_party/gogs/third_party-gogs.md'
+    - 'mailcow Alias Generator': 'third_party/mailcow-alias-generator/third_party-mailcow-alias-generator.md'
     - 'mailcow Logs Viewer': 'third_party/mailcow-logs-viewer/third_party-mailcow-logs-viewer.md'
     - 'Mailman 3': 'third_party/mailman3/third_party-mailman3.md'
     - 'Mailpiler Integration': 'third_party/mailpiler/third_party-mailpiler_integration.md'


### PR DESCRIPTION
Adds [mailcow Alias Generator](https://github.com/Upellift99/mailcow-alias-generator)
to the community-managed third-party section.

It is a small, self-hosted web app that creates aliases through the mailcow API,
so every service can be given its own throwaway address that redirects to the
real inbox. Multi-user, multi-domain, ships a published container image, and has
an optional ALTCHA captcha on the login form. GPL-3.0.

### What is in here

- `third_party-mailcow-alias-generator.en.md`
- `third_party-mailcow-alias-generator.de.md`
- one nav entry in `mkdocs.yml`, in alphabetical position before `mailcow Logs Viewer`

The page follows the layout of the existing entries — features, requirements,
installation, configuration — and uses the compose switch for both syntaxes as
the contributing notes ask. The trademark is spelled lowercase throughout,
including in the display name, matching how `mailcow Logs Viewer` is registered.

### Verification

Built locally with the pinned `requirements.txt`:

- `mkdocs build` completes with no errors
- both locales render at
  `third_party/mailcow-alias-generator/third_party-mailcow-alias-generator/`
- the compose switch produces the two expected tabs in each locale
- the nav entry appears on the sibling pages

Happy to adjust the wording or trim the page if you would rather keep these
entries shorter.
